### PR TITLE
rewrite npmignore to ignore specifics

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,10 @@ src/
 test/
 theme/
 
+.npmrc
+.yarnrc
+
 circle.yml
-ts*.*
+tsconfig.json
+tslint.json
 yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,8 @@
-**/*
-!README.md
-!LICENSE
-!PATENTS
-!package.json
-!typings/**/*
-!dist/**/*
+docs/
+src/
+test/
+theme/
+
+circle.yml
+ts*.*
+yarn.lock


### PR DESCRIPTION
instead of ignoring everything and including specifics (which did not include cli.js).

tested via `npm install path/to/documentalist` locally. does not produce the error in https://circleci.com/gh/palantir/blueprint/1994.