### PR TITLE
new Compiler class is passed to plugins

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,0 +1,130 @@
+import * as yaml from "js-yaml";
+import * as marked from "marked";
+
+import { StringOrTag } from "./client";
+
+/**
+ * Matches the triple-dash metadata block on the first line of markdown file.
+ * The first capture group contains YAML content.
+ */
+const METADATA_REGEX = /^---\n?((?:.|\n)*)\n---\n/;
+
+/**
+ * Splits text content for lines that begin with `@tagName`.
+ */
+const TAG_REGEX = /^@(\S+)(?:\s+([^\n]+))?$/;
+const TAG_SPLIT_REGEX = /^(@\S+(?:\s+[^\n]+)?)$/gm;
+
+/**
+ * Ignored `@tag` names. Some languages already support `@tags`, so to separate
+ * Documentalist tags, we use these default reserved words to avoid conflicts.
+ *
+ * Plugins may define their own reserved words when calling the `renderBlock`
+ * method.
+ */
+const RESERVED_WORDS = [
+    "import",
+];
+
+/**
+ * The output of `renderBlock` which parses a long form documentation block into
+ * metadata, rendered markdown, and tags.
+ */
+export interface IBlock {
+    /**
+     * The original string content block.
+     */
+    content: string;
+
+    /**
+     * Parsed YAML front matter (if any) or {}.
+     */
+    metadata: any;
+
+    /**
+     * An array of markdown-rendered HTML or tags.
+     */
+    renderedContent: StringOrTag[];
+}
+
+export interface ICompiler {
+    /**
+     * Converts an array of entries into a map of key to entry, using given
+     * callback to extract key from each item.
+     */
+    objectify: <T>(array: T[], getKey: (item: T) => string) => { [key: string]: T };
+
+    /**
+     * Render a block of content by extracting metadata (YAML front matter) and
+     * splitting text content into markdown-rendered HTML strings and `{ tag,
+     * value }` objects.
+     *
+     * To prevent special strings like "@include" from being parsed, a reserved
+     * tag words array may be provided, in which case the line will be left as
+     * is.
+     */
+    renderBlock: (blockContent: string, reservedTagWords?: string[]) => IBlock;
+}
+
+export class Compiler implements ICompiler {
+    public constructor(private markedOptions: MarkedOptions) {
+    }
+
+    public objectify<T>(array: T[], getKey: (item: T) => string) {
+        return array.reduce((obj, item) => {
+            obj[getKey(item)] = item;
+            return obj;
+        }, {} as { [key: string]: T });
+    }
+
+    public renderBlock = (blockContent: string, reservedTagWords = RESERVED_WORDS): IBlock => {
+        const { content, metadata } = this.extractMetadata(blockContent);
+        const renderedContent = this.renderContents(content, reservedTagWords);
+        return { content, metadata, renderedContent };
+    }
+
+    /**
+     * Converts the content string into an array of `ContentNode`s. If the
+     * `contents` option is `html`, the string nodes will also be rendered with
+     * markdown.
+     */
+    private renderContents(content: string, reservedTagWords: string[]) {
+        const splitContents = this.parseTags(content, reservedTagWords);
+        return splitContents
+            .map((node) => typeof node === "string" ? marked(node, this.markedOptions) : node)
+            .filter((node) => node !== "");
+    }
+
+    /**
+     * Extracts optional YAML frontmatter metadata block from the beginning of a
+     * markdown file and parses it to a JS object.
+     */
+    private extractMetadata(text: string) {
+        const match = METADATA_REGEX.exec(text);
+        if (match === null) {
+            return { content: text, metadata: {} };
+        }
+
+        const content = text.substr(match[0].length);
+        return { content, metadata: yaml.load(match[1]) || {} };
+    }
+
+    /**
+     * Splits the content string when it encounters a line that begins with a
+     * `@tag`. You may prevent this splitting by specifying an array of reserved
+     * tag names.
+     */
+    private parseTags(content: string, reservedWords: string[]) {
+        return content.split(TAG_SPLIT_REGEX).map((str): StringOrTag => {
+            const match = TAG_REGEX.exec(str);
+            if (match === null || reservedWords.indexOf(match[1]) >= 0) {
+                return str;
+            } else {
+                return {
+                    tag: match[1],
+                    value: match[2],
+                };
+            }
+        });
+    }
+}

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,7 +1,7 @@
 import * as yaml from "js-yaml";
 import * as marked from "marked";
 
-import { StringOrTag } from "./client";
+import { IBlock, ICompiler, StringOrTag } from "./plugins/plugin";
 
 /**
  * Matches the triple-dash metadata block on the first line of markdown file.
@@ -25,46 +25,6 @@ const TAG_SPLIT_REGEX = /^(@\S+(?:\s+[^\n]+)?)$/gm;
 const RESERVED_WORDS = [
     "import",
 ];
-
-/**
- * The output of `renderBlock` which parses a long form documentation block into
- * metadata, rendered markdown, and tags.
- */
-export interface IBlock {
-    /**
-     * The original string content block.
-     */
-    content: string;
-
-    /**
-     * Parsed YAML front matter (if any) or {}.
-     */
-    metadata: any;
-
-    /**
-     * An array of markdown-rendered HTML or tags.
-     */
-    renderedContent: StringOrTag[];
-}
-
-export interface ICompiler {
-    /**
-     * Converts an array of entries into a map of key to entry, using given
-     * callback to extract key from each item.
-     */
-    objectify: <T>(array: T[], getKey: (item: T) => string) => { [key: string]: T };
-
-    /**
-     * Render a block of content by extracting metadata (YAML front matter) and
-     * splitting text content into markdown-rendered HTML strings and `{ tag,
-     * value }` objects.
-     *
-     * To prevent special strings like "@include" from being parsed, a reserved
-     * tag words array may be provided, in which case the line will be left as
-     * is.
-     */
-    renderBlock: (blockContent: string, reservedTagWords?: string[]) => IBlock;
-}
 
 export class Compiler implements ICompiler {
     public constructor(private markedOptions: MarkedOptions) {

--- a/src/documentalist.ts
+++ b/src/documentalist.ts
@@ -7,10 +7,8 @@
 
 import * as fs from "fs";
 import * as glob from "glob";
-import * as yaml from "js-yaml";
-import * as marked from "marked";
 import * as path from "path";
-import { StringOrTag } from "./client";
+import { Compiler } from "./compiler";
 import {
     IFile,
     IMarkdownPluginData,
@@ -19,29 +17,6 @@ import {
     MarkdownPlugin,
     TypescriptPlugin,
 } from "./plugins";
-
-/**
- * Matches the triple-dash metadata block on the first line of markdown file.
- * The first capture group contains YAML content.
- */
-const METADATA_REGEX = /^---\n?((?:.|\n)*)\n---\n/;
-
-/**
- * Splits text content for lines that begin with `@tagName`.
- */
-const TAG_REGEX = /^@(\S+)(?:\s+([^\n]+))?$/;
-const TAG_SPLIT_REGEX = /^(@\S+(?:\s+[^\n]+)?)$/gm;
-
-/**
- * Ignored `@tag` names. Some languages already support `@tags`, so to separate
- * Documentalist tags, we use these default reserved words to avoid conflicts.
- *
- * Plugins may define their own reserved words when calling the `renderBlock`
- * method.
- */
-const RESERVED_WORDS = [
-    "import",
-];
 
 export interface IApi<T> {
     /**
@@ -63,23 +38,6 @@ export interface IApi<T> {
     documentFiles: (files: IFile[]) => Promise<T>;
 
     /**
-     * Converts an array of entries into a map of key to entry, using given
-     * callback to extract key from each item.
-     */
-    objectify: <T>(array: T[], getKey: (item: T) => string) => { [key: string]: T };
-
-    /**
-     * Render a block of content by extracting metadata (YAML front matter) and
-     * splitting text content into markdown-rendered HTML strings and `{ tag,
-     * value }` objects.
-     *
-     * To prevent special strings like "@include" from being parsed, a reserved
-     * tag words array may be provided, in which case the line will be left as
-     * is.
-     */
-    renderBlock: (blockContent: string, reservedTagWords?: string[]) => IBlock;
-
-    /**
      * Adds the plugin to Documentalist. Returns a new instance of Documentalist
      * with a template type that includes the data from the plugin. This way the
      * `documentFiles` and `documentGlobs` methods will return an object that is
@@ -98,27 +56,6 @@ export interface IApi<T> {
      * Returns a new instance of Documentalist with no plugins.
      */
     clearPlugins(): IApi<{}>;
-}
-
-/**
- * The output of `renderBlock` which parses a long form documentation block into
- * metadata, rendered markdown, and tags.
- */
-export interface IBlock {
-    /**
-     * The original string content block.
-     */
-    content: string;
-
-    /**
-     * Parsed YAML front matter (if any) or {}.
-     */
-    metadata: any;
-
-    /**
-     * An array of markdown-rendered HTML or tags.
-     */
-    renderedContent: StringOrTag[];
 }
 
 /**
@@ -160,35 +97,14 @@ export class Documentalist<T> implements IApi<T> {
     }
 
     public async documentFiles(files: IFile[]) {
+        const compiler = new Compiler(this.markedOptions);
         const documentation = {} as T;
         for (const { pattern, plugin } of this.plugins) {
-            const pluginDocumentation = await plugin.compile(this, files.filter((f) => pattern.test(f.path)));
-            for (const key in pluginDocumentation) {
-                if (pluginDocumentation.hasOwnProperty(key)) {
-                    if (documentation.hasOwnProperty(key)) {
-                        console.warn(`
-                            WARNING: Duplicate plugin key "${key}".
-                            Your plugins are overwriting each other.
-                        `);
-                    }
-                    documentation[key] = pluginDocumentation[key];
-                }
-            }
+            const pluginFiles = files.filter((f) => pattern.test(f.path));
+            const pluginDocumentation = await plugin.compile(pluginFiles, compiler);
+            this.mergeInto(documentation, pluginDocumentation);
         }
         return documentation;
-    }
-
-    public objectify<T>(array: T[], getKey: (item: T) => string) {
-        return array.reduce((obj, item) => {
-            obj[getKey(item)] = item;
-            return obj;
-        }, {} as { [key: string]: T });
-    }
-
-    public renderBlock(blockContent: string, reservedTagWords = RESERVED_WORDS): IBlock {
-        const { content, metadata } = this.extractMetadata(blockContent);
-        const renderedContent = this.renderContents(content, reservedTagWords);
-        return { content, metadata, renderedContent };
     }
 
     /**
@@ -208,47 +124,17 @@ export class Documentalist<T> implements IApi<T> {
     }
 
     /**
-     * Converts the content string into an array of `ContentNode`s. If the
-     * `contents` option is `html`, the string nodes will also be rendered with
-     * markdown.
+     * Shallow-merges keys form source into destination object (modifying it in the process).
      */
-    private renderContents(content: string, reservedTagWords: string[]) {
-        const splitContents = this.parseTags(content, reservedTagWords);
-        return splitContents
-            .map((node) => typeof node === "string" ? marked(node, this.markedOptions) : node)
-            .filter((node) => node !== "");
-    }
-
-    /**
-     * Extracts optional YAML frontmatter metadata block from the beginning of a
-     * markdown file and parses it to a JS object.
-     */
-    private extractMetadata(text: string) {
-        const match = METADATA_REGEX.exec(text);
-        if (match === null) {
-            return { content: text, metadata: {} };
-        }
-
-        const content = text.substr(match[0].length);
-        return { content, metadata: yaml.load(match[1]) || {} };
-    }
-
-    /**
-     * Splits the content string when it encounters a line that begins with a
-     * `@tag`. You may prevent this splitting by specifying an array of reserved
-     * tag names.
-     */
-    private parseTags(content: string, reservedWords: string[]) {
-        return content.split(TAG_SPLIT_REGEX).map((str): StringOrTag => {
-            const match = TAG_REGEX.exec(str);
-            if (match === null || reservedWords.indexOf(match[1]) >= 0) {
-                return str;
-            } else {
-                return {
-                    tag: match[1],
-                    value: match[2],
-                };
+    private mergeInto(destination: T, source: T) {
+        for (const key in source) {
+            if (source.hasOwnProperty(key)) {
+                if (destination.hasOwnProperty(key)) {
+                    console.warn(`WARNING: Duplicate plugin key "${key}". Your plugins are overwriting each other.`);
+                }
+                destination[key] = source[key];
             }
-        });
+        }
+        return destination;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,5 @@
  */
 
 export * from "./client";
-export * from "./compiler";
 export * from "./documentalist";
 export * from "./plugins";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,5 +5,7 @@
  * repository.
  */
 
+export * from "./client";
+export * from "./compiler";
 export * from "./documentalist";
 export * from "./plugins";

--- a/src/plugins/css.ts
+++ b/src/plugins/css.ts
@@ -9,8 +9,7 @@ import * as postcss from "postcss";
 import { Comment, Root, Rule } from "postcss";
 import * as postcssScss from "postcss-scss";
 import { StringOrTag } from "../client";
-import { ICompiler } from "../compiler";
-import { IFile, IPlugin } from "./plugin";
+import { ICompiler, IFile, IPlugin } from "./plugin";
 
 export interface ICssDeclaration {
     prop: string;

--- a/src/plugins/css.ts
+++ b/src/plugins/css.ts
@@ -8,9 +8,8 @@
 import * as postcss from "postcss";
 import { Comment, Root, Rule } from "postcss";
 import * as postcssScss from "postcss-scss";
-
-import { Documentalist } from "..";
 import { StringOrTag } from "../client";
+import { ICompiler } from "../compiler";
 import { IFile, IPlugin } from "./plugin";
 
 export interface ICssDeclaration {
@@ -37,12 +36,12 @@ export interface ICssPluginData {
 
 export class CssPlugin implements IPlugin<ICssPluginData> {
 
-    public compile(documentalist: Documentalist<ICssPluginData>, cssFiles: IFile[]) {
+    public compile(cssFiles: IFile[], doc: ICompiler) {
         const css = [] as ICss[];
         cssFiles.forEach((file) => {
             const cssContent = file.read();
             const cssResult = {filePath: file.path, rules: []};
-            postcss([this.processor(documentalist, cssResult)])
+            postcss([this.processor(doc, cssResult)])
                 .process(cssContent, { syntax: postcssScss })
                 .css; // this statement makes the whole thing synchronous
             css.push(cssResult);
@@ -50,7 +49,7 @@ export class CssPlugin implements IPlugin<ICssPluginData> {
         return { css };
     }
 
-    private processor(documentalist: Documentalist<ICssPluginData>, cssResult: ICss) {
+    private processor(doc: ICompiler, cssResult: ICss) {
         return (css: Root) => {
             css.walkRules((rule: Rule) => {
                 const ruleResult = {
@@ -65,7 +64,7 @@ export class CssPlugin implements IPlugin<ICssPluginData> {
                         .replace(/\n *\*+ */g, "\n")
                         .trim(); // trim asterisks, maintain newlines
 
-                    const { content, metadata, renderedContent } = documentalist.renderBlock(block);
+                    const { content, metadata, renderedContent } = doc.renderBlock(block);
                     ruleResult.metadata = metadata;
                     ruleResult.commentRaw = content;
                     ruleResult.comment = renderedContent;

--- a/src/plugins/markdown.ts
+++ b/src/plugins/markdown.ts
@@ -6,9 +6,8 @@
  */
 
 import { IPageData, StringOrTag } from "../client";
-import { ICompiler } from "../compiler";
 import { makePage } from "../page";
-import { IFile, IPlugin } from "./plugin";
+import { ICompiler, IFile, IPlugin } from "./plugin";
 
 export interface IMarkdownPluginData {
     docs: {

--- a/src/plugins/markdown.ts
+++ b/src/plugins/markdown.ts
@@ -5,8 +5,8 @@
  * repository.
  */
 
-import { Documentalist } from "..";
 import { IPageData, StringOrTag } from "../client";
+import { ICompiler } from "../compiler";
 import { makePage } from "../page";
 import { IFile, IPlugin } from "./plugin";
 
@@ -21,13 +21,13 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
      * Reads the given set of markdown files and adds their data to the internal storage.
      * Returns a plain object mapping page references to their data.
      */
-    public compile(documentalist: Documentalist<IMarkdownPluginData>, markdownFiles: IFile[]) {
+    public compile(markdownFiles: IFile[], { renderBlock }: ICompiler) {
         const pageStore: Map<string, IPageData> = new Map();
         markdownFiles
             .map((file) => {
                 const absolutePath = file.path;
                 const fileContents = file.read();
-                const { content, metadata, renderedContent } = documentalist.renderBlock(fileContents);
+                const { content, metadata, renderedContent } = renderBlock(fileContents);
                 const page = makePage({
                     absolutePath,
                     contentRaw: content,

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -5,7 +5,7 @@
  * repository.
  */
 
-import { Documentalist } from "..";
+import { ICompiler } from "../compiler";
 
 export interface IFile {
     path: string;
@@ -13,5 +13,5 @@ export interface IFile {
 }
 
 export interface IPlugin<T> {
-    compile: (doc: Documentalist<T>, files: IFile[]) => T | Promise<T>;
+    compile: (files: IFile[], doc: ICompiler) => T | Promise<T>;
 }

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -9,6 +9,9 @@ import { StringOrTag } from "../client";
 
 export { StringOrTag };
 
+/**
+ * Abstract representation of a file, containing absolute path and synchronous `read` operation.
+ */
 export interface IFile {
     path: string;
     read: () => string;
@@ -35,6 +38,9 @@ export interface IBlock {
     renderedContent: StringOrTag[];
 }
 
+/**
+ * Each plugin receives a `Compiler` instance to aid in the processing of source files.
+ */
 export interface ICompiler {
     /**
      * Converts an array of entries into a map of key to entry, using given

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -5,11 +5,53 @@
  * repository.
  */
 
-import { ICompiler } from "../compiler";
+import { StringOrTag } from "../client";
+
+export { StringOrTag };
 
 export interface IFile {
     path: string;
     read: () => string;
+}
+
+/**
+ * The output of `renderBlock` which parses a long form documentation block into
+ * metadata, rendered markdown, and tags.
+ */
+export interface IBlock {
+    /**
+     * The original string content block.
+     */
+    content: string;
+
+    /**
+     * Parsed YAML front matter (if any) or {}.
+     */
+    metadata: any;
+
+    /**
+     * An array of markdown-rendered HTML or tags.
+     */
+    renderedContent: StringOrTag[];
+}
+
+export interface ICompiler {
+    /**
+     * Converts an array of entries into a map of key to entry, using given
+     * callback to extract key from each item.
+     */
+    objectify: <T>(array: T[], getKey: (item: T) => string) => { [key: string]: T };
+
+    /**
+     * Render a block of content by extracting metadata (YAML front matter) and
+     * splitting text content into markdown-rendered HTML strings and `{ tag,
+     * value }` objects.
+     *
+     * To prevent special strings like "@include" from being parsed, a reserved
+     * tag words array may be provided, in which case the line will be left as
+     * is.
+     */
+    renderBlock: (blockContent: string, reservedTagWords?: string[]) => IBlock;
 }
 
 export interface IPlugin<T> {

--- a/src/plugins/typescript.ts
+++ b/src/plugins/typescript.ts
@@ -6,8 +6,7 @@
  */
 
 import tsdoc, { IJsDocTags } from "ts-quick-docs";
-import { IBlock, ICompiler } from "../compiler";
-import { IFile, IPlugin } from "./plugin";
+import { IBlock, ICompiler, IFile, IPlugin } from "./plugin";
 
 export interface ITsDocEntry {
     documentation: IBlock;

--- a/src/plugins/typescript.ts
+++ b/src/plugins/typescript.ts
@@ -6,7 +6,7 @@
  */
 
 import tsdoc, { IJsDocTags } from "ts-quick-docs";
-import { Documentalist, IBlock } from "..";
+import { IBlock, ICompiler } from "../compiler";
 import { IFile, IPlugin } from "./plugin";
 
 export interface ITsDocEntry {
@@ -33,16 +33,16 @@ export interface ITypescriptPluginData {
 }
 
 export class TypescriptPlugin implements IPlugin<ITypescriptPluginData> {
-    public compile(documentalist: Documentalist<ITypescriptPluginData>, files: IFile[]) {
+    public compile(files: IFile[], { renderBlock, objectify }: ICompiler) {
         const entries = tsdoc.fromFiles(files.map((f) => f.path), {}).map<ITsInterfaceEntry>((entry) => ({
             ...entry,
-            documentation: documentalist.renderBlock(entry.documentation),
+            documentation: renderBlock(entry.documentation),
             properties: entry.properties!.map<ITsPropertyEntry>((prop) => ({
                 ...prop,
-                documentation: documentalist.renderBlock(prop.documentation),
+                documentation: renderBlock(prop.documentation),
             })),
         }));
-        const ts = documentalist.objectify(entries, (e) => e.name);
+        const ts = objectify(entries, (e) => e.name);
         return { ts };
     }
 }

--- a/test/compilerTests.ts
+++ b/test/compilerTests.ts
@@ -7,10 +7,10 @@
 
 import { assert } from "chai";
 import "mocha";
-import { Documentalist } from "../src";
+import { Compiler } from "../src";
 
-describe("Documentalist", () => {
-    const API = Documentalist.create();
+describe("Compiler", () => {
+    const API = new Compiler({});
 
     describe("metadata", () => {
         const METADATA = "---\nhello: world\nsize: 1000\n---\n";

--- a/test/compilerTests.ts
+++ b/test/compilerTests.ts
@@ -7,7 +7,7 @@
 
 import { assert } from "chai";
 import "mocha";
-import { Compiler } from "../src";
+import { Compiler } from "../src/compiler";
 
 describe("Compiler", () => {
     const API = new Compiler({});


### PR DESCRIPTION
all the `renderBlock` logic moves to a separate class :ok_hand:.
also swap `compile()` args so files comes first--easier usage if plugin doesn't need compiler.