### PR TITLE
MarkdownPlugin generates nav layout too!

### DIFF
--- a/docs/assets/index.js
+++ b/docs/assets/index.js
@@ -1,7 +1,8 @@
 class Router {
-    constructor(el) {
+    constructor(el, defaultRoute = "") {
         this.el = el;
         this.routes = {};
+        this.defaultRoute = defaultRoute;
     }
 
     start() {
@@ -16,7 +17,7 @@ class Router {
     }
 
     route() {
-        const hashRoute = location.hash.slice(1) || "";
+        const hashRoute = location.hash.slice(1) || this.defaultRoute;
         const route = this.routes[hashRoute];
 
         if (this.el && route && route !== this.currentRoute) {
@@ -39,7 +40,7 @@ function selectCurrent(route) {
     }
 }
 
-const router = new Router(document.querySelector("#content"));
+const router = new Router(document.querySelector("#content"), "docs");
 const routables = document.querySelectorAll("[data-route]");
 routables.forEach((routable) => {
     const route = routable.getAttribute("data-route");

--- a/src/_nav.md
+++ b/src/_nav.md
@@ -1,0 +1,1 @@
+@page docs

--- a/src/client.ts
+++ b/src/client.ts
@@ -95,39 +95,5 @@ export function isPageNode(node: any): node is IPageNode {
 
 /** Slugify a string: "Really Cool Heading!" => "really-cool-heading-" */
 export function slugify(str: string) {
-    return str.toLowerCase().replace(/[^\w.]/g, "-");
-}
-
-function initPageNode({ reference, title }: IPageData, depth: number): IPageNode {
-    return { children: [], depth, reference, title };
-}
-
-function initHeadingNode(title: string, depth: number): IHeadingNode {
-    return { depth, reference: slugify(title), title };
-}
-
-/**
- * Organizes the pages into a tree structure by traversing
- * their contents for `@#+` and `@page` tags.
- */
-export function createNavigableTree(pages: { [key: string]: IPageData }, page: IPageData, depth = 0) {
-    const pageNode: IPageNode = initPageNode(page, depth);
-    if (page.contents != null) {
-        page.contents.forEach((node: StringOrTag, i: number) => {
-            if (isTag(node)) {
-                if (node.tag === "page") {
-                    const subpage = pages[node.value as string];
-                    if (subpage === undefined) {
-                        throw new Error(`Unknown @page '${node.value}' referenced in '${page.reference}'`);
-                    }
-                    pageNode.children.push(createNavigableTree(pages, subpage, depth + 1));
-                }
-                if (i !== 0 && node.tag.match(/^#+$/)) {
-                    // use heading strength - 1 cuz h1 is the title
-                    pageNode.children.push(initHeadingNode(node.value, depth + node.tag.length - 1));
-                }
-            }
-        });
-    }
-    return pageNode;
+    return str.toLowerCase().replace(/[^\w.\/]/g, "-");
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -97,3 +97,17 @@ export function isPageNode(node: any): node is IPageNode {
 export function slugify(str: string) {
     return str.toLowerCase().replace(/[^\w.\/]/g, "-");
 }
+
+/**
+ * Slugify heading text and join to page refernece with `.`.
+ */
+export function headingReference(parentReference: string, headingTitle: string) {
+    return [parentReference, slugify(headingTitle)].join(".");
+}
+
+/**
+ * Join page references with a `/` to indicate nesting.
+ */
+export function pageReference(parentReference: string, pageReference: string) {
+    return [parentReference, pageReference].join("/");
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -93,17 +93,17 @@ export function isPageNode(node: any): node is IPageNode {
     return (node as IPageNode).children !== undefined;
 }
 
-/** Merge an array of strings into one handy slug. */
-export function slugify(...strings: string[]) {
-    return strings.map((str) => str.toLowerCase().replace(/[^\w.]/g, "-")).join(".");
+/** Slugify a string: "Really Cool Heading!" => "really-cool-heading-" */
+export function slugify(str: string) {
+    return str.toLowerCase().replace(/[^\w.]/g, "-");
 }
 
 function initPageNode({ reference, title }: IPageData, depth: number): IPageNode {
     return { children: [], depth, reference, title };
 }
 
-function initHeadingNode({ value }: ITag, depth: number): IHeadingNode {
-    return { depth, reference: slugify(value), title: value };
+function initHeadingNode(title: string, depth: number): IHeadingNode {
+    return { depth, reference: slugify(title), title };
 }
 
 /**
@@ -124,7 +124,7 @@ export function createNavigableTree(pages: { [key: string]: IPageData }, page: I
                 }
                 if (i !== 0 && node.tag.match(/^#+$/)) {
                     // use heading strength - 1 cuz h1 is the title
-                    pageNode.children.push(initHeadingNode(node, depth + node.tag.length - 1));
+                    pageNode.children.push(initHeadingNode(node.value, depth + node.tag.length - 1));
                 }
             }
         });

--- a/src/docs.md
+++ b/src/docs.md
@@ -1,3 +1,7 @@
+---
+title: Documentalist
+---
+
 ## Documentalist
 
 **Documentalist** is a library for parsing documentation from **CSS**,

--- a/src/page.ts
+++ b/src/page.ts
@@ -19,7 +19,7 @@ export class PageMap {
      */
     public add(data: PartialPageData) {
         const page = makePage(data);
-        this.put(page.reference, page);
+        this.set(page.reference, page);
         return page;
     }
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -35,3 +35,41 @@ function getTitle(data: PartialPageData) {
 
     return "(untitled)";
 }
+
+export class PageMap {
+    private pages: Map<string, IPageData> = new Map();
+
+    public get(id: string) {
+        if (this.pages.has(id)) {
+            return this.pages.get(id)!;
+        } else {
+            throw new Error(`Unknown page: ${id}`);
+        }
+    }
+
+    public add(data: PartialPageData) {
+        const page = makePage(data);
+        if (this.pages.has(page.reference)) {
+            console.warn(`Found duplicate page "${page.reference}"; overwriting previous data.`);
+            console.warn("Rename headings or use metadata `reference` key to disambiguate.");
+        }
+        this.pages.set(page.reference, page);
+        return page;
+    }
+
+    public update(id: string, data: Partial<IPageData>) {
+        if (!this.pages.has(id)) {
+            throw new Error(`Unknown page: ${id}`);
+        }
+        const page = this.pages.get(id)!;
+        this.pages.set(id, { ...page, ...data });
+    }
+
+    public toObject() {
+        const object: { [key: string]: IPageData } = {};
+        for (const [key, val] of this.pages.entries()) {
+            object[key] = val;
+        }
+        return object;
+    }
+}

--- a/src/page.ts
+++ b/src/page.ts
@@ -23,19 +23,17 @@ export class PageMap {
         return page;
     }
 
-    /** Returns the page with the given ID, or throws an error if not found. */
+    /** Returns the page with the given ID or `undefined` if not found. */
     public get(id: string) {
-        if (this.pages.has(id)) {
-            return this.pages.get(id)!;
-        } else {
-            throw new Error(`Unknown page: ${id}`);
-        }
+        return this.pages.get(id);
     }
 
-    /** Removes the page with the given ID and returns it, or throws an error if not found. */
+    /** Removes the page with the given ID and returns it or `undefined` if not found. */
     public remove(id: string) {
         const page = this.get(id);
-        this.pages.delete(id);
+        if (page !== undefined) {
+            this.pages.delete(id);
+        }
         return page;
     }
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -13,14 +13,13 @@ export type PartialPageData = Pick<IPageData, "absolutePath" | "contentRaw" | "c
 export class PageMap {
     private pages: Map<string, IPageData> = new Map();
 
-    /** Adds a new page to the map. Generates title and reference from partial data. */
+    /**
+     * Adds a new page to the map. Generates title and reference from partial data.
+     * Use this for ingesting rendered blocks.
+     */
     public add(data: PartialPageData) {
         const page = makePage(data);
-        if (this.pages.has(page.reference)) {
-            console.warn(`Found duplicate page "${page.reference}"; overwriting previous data.`);
-            console.warn("Rename headings or use metadata `reference` key to disambiguate.");
-        }
-        this.pages.set(page.reference, page);
+        this.put(page.reference, page);
         return page;
     }
 
@@ -40,10 +39,16 @@ export class PageMap {
         return page;
     }
 
-    /** Merges the given data into the page with the given ID, or throws an error if not found. */
-    public update(id: string, data: Partial<IPageData>) {
-        const page = this.get(id);
-        this.pages.set(id, { ...page, ...data });
+    /**
+     * Sets the page data at the given ID, when you already have a full page object.
+     * Warns if a page with this ID already exists.
+     */
+    public set(id: string, page: IPageData) {
+        if (this.pages.has(id)) {
+            console.warn(`Found duplicate page "${id}"; overwriting previous data.`);
+            console.warn("Rename headings or use metadata `reference` key to disambiguate.");
+        }
+        this.pages.set(id, page);
     }
 
     /** Returns a JS object mapping page IDs to data. */

--- a/src/page.ts
+++ b/src/page.ts
@@ -39,14 +39,7 @@ function getTitle(data: PartialPageData) {
 export class PageMap {
     private pages: Map<string, IPageData> = new Map();
 
-    public get(id: string) {
-        if (this.pages.has(id)) {
-            return this.pages.get(id)!;
-        } else {
-            throw new Error(`Unknown page: ${id}`);
-        }
-    }
-
+    /** Adds a new page to the map. Generates title and reference from partial data. */
     public add(data: PartialPageData) {
         const page = makePage(data);
         if (this.pages.has(page.reference)) {
@@ -57,14 +50,29 @@ export class PageMap {
         return page;
     }
 
-    public update(id: string, data: Partial<IPageData>) {
-        if (!this.pages.has(id)) {
+    /** Returns the page with the given ID, or throws an error if not found. */
+    public get(id: string) {
+        if (this.pages.has(id)) {
+            return this.pages.get(id)!;
+        } else {
             throw new Error(`Unknown page: ${id}`);
         }
-        const page = this.pages.get(id)!;
+    }
+
+    /** Removes the page with the given ID and returns it, or throws an error if not found. */
+    public remove(id: string) {
+        const page = this.get(id);
+        this.pages.delete(id);
+        return page;
+    }
+
+    /** Merges the given data into the page with the given ID, or throws an error if not found. */
+    public update(id: string, data: Partial<IPageData>) {
+        const page = this.get(id);
         this.pages.set(id, { ...page, ...data });
     }
 
+    /** Returns a JS object mapping page IDs to data. */
     public toObject() {
         const object: { [key: string]: IPageData } = {};
         for (const [key, val] of this.pages.entries()) {

--- a/src/page.ts
+++ b/src/page.ts
@@ -10,32 +10,6 @@ import { IPageData, isTag } from "./client";
 
 export type PartialPageData = Pick<IPageData, "absolutePath" | "contentRaw" | "contents" | "metadata">;
 
-export function makePage(props: PartialPageData): IPageData {
-    const title = getTitle(props);
-    const reference = getReference(props);
-    return { ...props, reference, title };
-}
-
-function getReference(data: PartialPageData) {
-    if (data.metadata.reference != null) {
-        return data.metadata.reference;
-    }
-    return path.basename(data.absolutePath, path.extname(data.absolutePath));
-}
-
-function getTitle(data: PartialPageData) {
-    if (data.metadata.title !== undefined) {
-        return data.metadata.title;
-    }
-
-    const first = data.contents[0];
-    if (isTag(first) && first.tag.match(/^#+$/)) {
-        return first.value as string;
-    }
-
-    return "(untitled)";
-}
-
 export class PageMap {
     private pages: Map<string, IPageData> = new Map();
 
@@ -80,4 +54,30 @@ export class PageMap {
         }
         return object;
     }
+}
+
+function makePage(props: PartialPageData): IPageData {
+    const title = getTitle(props);
+    const reference = getReference(props);
+    return { ...props, reference, title };
+}
+
+function getReference(data: PartialPageData) {
+    if (data.metadata.reference != null) {
+        return data.metadata.reference;
+    }
+    return path.basename(data.absolutePath, path.extname(data.absolutePath));
+}
+
+function getTitle(data: PartialPageData) {
+    if (data.metadata.title !== undefined) {
+        return data.metadata.title;
+    }
+
+    const first = data.contents[0];
+    if (isTag(first) && first.tag.match(/^#+$/)) {
+        return first.value as string;
+    }
+
+    return "(untitled)";
 }

--- a/src/plugins/markdown.ts
+++ b/src/plugins/markdown.ts
@@ -20,7 +20,14 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
      * Reads the given set of markdown files and adds their data to the internal storage.
      * Returns a plain object mapping page references to their data.
      */
-    public compile(markdownFiles: IFile[], { renderBlock }: ICompiler) {
+    public compile(markdownFiles: IFile[], compiler: ICompiler) {
+        const pageStore = this.buildPageMap(markdownFiles, compiler);
+        return {
+            pages: pageStore.toObject(),
+        };
+    }
+
+    private buildPageMap(markdownFiles: IFile[], { renderBlock }: ICompiler) {
         const pageStore: PageMap = new PageMap();
         markdownFiles
             .map((file) => {
@@ -48,7 +55,6 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
                 }, [] as StringOrTag[]);
                 return page;
             });
-        const pages = pageStore.toObject();
-        return { pages };
+        return pageStore;
     }
 }

--- a/src/plugins/markdown.ts
+++ b/src/plugins/markdown.ts
@@ -44,7 +44,7 @@ export interface IMarkdownPluginOptions {
 export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
     private options: IMarkdownPluginOptions;
 
-    public constructor(options: Partial<IMarkdownPluginOptions>) {
+    public constructor(options: Partial<IMarkdownPluginOptions> = {}) {
         this.options = {
             headingSeparator: ".",
             navPage: "_nav",

--- a/test/pluginsTests.ts
+++ b/test/pluginsTests.ts
@@ -46,7 +46,7 @@ const TEST_FILES = [
 describe("Plugins", () => {
     it("can document Markdown files", async () => {
         const docs = await Documentalist.create().documentFiles(TEST_FILES);
-        const page = docs.docs["test"];
+        const page = docs.pages["test"];
         expect(page).to.exist;
         expect(page.metadata["key"]).to.equal("value");
         expect(page.contents).with.lengthOf(3);

--- a/theme/index.pug
+++ b/theme/index.pug
@@ -21,8 +21,9 @@ html
   link(rel='stylesheet', href='assets/index.css')
 body
   #nav
-    a(href="#")
-      h3 Documentalist
+    each item in nav
+      a(href="#" + item.reference)
+        h3= item.title
 
     h3 Interfaces
     each ifaceName in toc
@@ -57,7 +58,7 @@ body
 
 
   .hidden(data-route="")
-    for block in docs.docs.contents
+    for block in pages.docs.contents
       if typeof block === "string"
         | !{block}
       else if block.tag === "interface"

--- a/theme/index.pug
+++ b/theme/index.pug
@@ -57,13 +57,14 @@ body
                 +joinContent(prop.documentation)
 
 
-  .hidden(data-route="")
-    for block in pages.docs.contents
-      if typeof block === "string"
-        | !{block}
-      else if block.tag === "interface"
-        - var iface = ts[block.value]
-        +interface(iface)
+  each page in pages
+    .hidden(data-route=page.reference)
+      for block in page.contents
+        if typeof block === "string"
+          | !{block}
+        else if block.tag === "interface"
+          - var iface = ts[block.value]
+          +interface(iface)
 
   each iface in ts
     if iface.type == "interface"


### PR DESCRIPTION
`MarkdownPlugin` outputs `{ nav, pages }` where `nav` is tree describing page/heading layout and `pages` is a map of data for each page.

new `PageMap` class wraps a `Map` with some use-case-specific operations to simplify usage.

update the pug theme so it's ready to support multiple pages.