### PR TITLE
MarkdownPlugin populates `route` property

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -73,7 +73,7 @@ export interface IPageData {
 
 /** One page entry in a layout tree. */
 export interface ITreeEntry {
-    depth?: number;
+    depth: number;
     reference: string;
     title: string;
 }
@@ -81,6 +81,7 @@ export interface ITreeEntry {
 /** A page has ordered children composed of `@#+` and `@page` tags. */
 export interface IPageNode extends ITreeEntry {
     children: Array<IPageNode | IHeadingNode>;
+    parentReference?: string;
 }
 
 /** An `@#+` tag belongs to a specific page. */

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,3 @@
-import { StringOrTag } from "./plugins/plugin";
 /**
  * Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
  * Licensed under the BSD-3 License as modified (the “License”); you may obtain

--- a/src/client.ts
+++ b/src/client.ts
@@ -95,6 +95,9 @@ export interface IPageData {
     /** Unique identifier for addressing this page. */
     reference: string;
 
+    /** Fully qualified route to this page: slash-separated references of all parent pages. */
+    route: string;
+
     /** Human-friendly title of this page. */
     title: string;
 }
@@ -102,14 +105,14 @@ export interface IPageData {
 /** One page entry in a layout tree. */
 export interface ITreeEntry {
     depth: number;
-    reference: string;
+    route: string;
     title: string;
 }
 
 /** A page has ordered children composed of `@#+` and `@page` tags. */
 export interface IPageNode extends ITreeEntry {
+    reference: string;
     children: Array<IPageNode | IHeadingNode>;
-    parentReference?: string;
 }
 
 /** An `@#+` tag belongs to a specific page. */
@@ -125,18 +128,4 @@ export function isPageNode(node: any): node is IPageNode {
 /** Slugify a string: "Really Cool Heading!" => "really-cool-heading-" */
 export function slugify(str: string) {
     return str.toLowerCase().replace(/[^\w.\/]/g, "-");
-}
-
-/**
- * Slugify heading text and join to page refernece with `.`.
- */
-export function headingReference(parentReference: string, headingTitle: string) {
-    return [parentReference, slugify(headingTitle)].join(".");
-}
-
-/**
- * Join page references with a `/` to indicate nesting.
- */
-export function pageReference(parentReference: string, pageReference: string) {
-    return [parentReference, pageReference].join("/");
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,3 +1,4 @@
+import { StringOrTag } from "./plugins/plugin";
 /**
  * Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
  * Licensed under the BSD-3 License as modified (the “License”); you may obtain
@@ -7,16 +8,43 @@
 
 /** Represents a single `@tag <value>` line from a file. */
 export interface ITag {
+    /** Tag name. */
     tag: string;
+    /** Tag value, exactly as written in source. */
     value: string;
+}
+
+/**
+ * Represents a single `@#+ <value>` heading tag from a file. Note that all `@#+` tags
+ * (`@#` through `@######`) are emitted as `tag: "heading"` so only one renderer is necessary to
+ * capture all six levels.
+ *
+ * Heading tags include additional information over regular tags: fully-qualified `route` of the
+ * heading (which can be used as anchor `href`), and `level` to determine which `<h#>` tag to use.
+ */
+export interface IHeadingTag extends ITag {
+    tag: "heading";
+    /** Fully-qualified route of the heading, which can be used as anchor `href`. */
+    route: string;
+    /** Level of heading, from 1-6. Dictates which `<h#>` tag to render. */
+    level: number;
 }
 
 /** An entry in `contents` array: either an HTML string or an `@tag`. */
 export type StringOrTag = string | ITag;
 
-/** type guard to determine if a `contents` node is an `@tag` statement */
-export function isTag(node: StringOrTag): node is ITag {
-    return (node as ITag).tag !== undefined;
+/**
+ * Type guard to determine if a `contents` node is an `@tag` statement.
+ * Optionally tests tag name too, if `tagName` arg is provided.
+ */
+export function isTag(node: StringOrTag, tagName?: string): node is ITag {
+    return node != null && (node as ITag).tag !== undefined
+        && (tagName === undefined || (node as ITag).tag === tagName);
+}
+
+/** Type guard to deterimine if a `contents` node is an `@#+` heading tag. */
+export function isHeadingTag(node: StringOrTag): node is IHeadingTag {
+    return isTag(node, "heading");
 }
 
 /**

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -87,7 +87,7 @@ export class Compiler implements ICompiler {
             const value = match[2];
             if (/#+/.test(tag)) {
                 // NOTE: not enough information to populate `route` field yet
-                return { level: tag.length, tag: "heading", value } as IHeadingTag;
+                return { tag: "heading", value, level: tag.length } as IHeadingTag;
             } else {
                 return { tag, value };
             }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,6 +1,7 @@
 import * as yaml from "js-yaml";
 import * as marked from "marked";
 
+import { IHeadingTag } from "./client";
 import { IBlock, ICompiler, StringOrTag } from "./plugins/plugin";
 
 /**
@@ -81,11 +82,14 @@ export class Compiler implements ICompiler {
             const match = TAG_REGEX.exec(str);
             if (match === null || reservedWords.indexOf(match[1]) >= 0) {
                 return str;
+            }
+            const tag = match[1];
+            const value = match[2];
+            if (/#+/.test(tag)) {
+                // NOTE: not enough information to populate `route` field yet
+                return { level: tag.length, tag: "heading", value } as IHeadingTag;
             } else {
-                return {
-                    tag: match[1],
-                    value: match[2],
-                };
+                return { tag, value };
             }
         });
     }

--- a/src/page.ts
+++ b/src/page.ts
@@ -71,11 +71,11 @@ export class PageMap {
         }
         const pageNode = initPageNode(page, depth);
         page.contents.forEach((node) => {
-            // we only care about @page and @#+ tag nodes
+            // we only care about @page and @##+ tag nodes
             if (isTag(node, "page")) {
                 pageNode.children.push(this.toTree(node.value, depth + 1));
             } else if (isHeadingTag(node) && node.level > 1) {
-                // use heading strength - 1 cuz h1 is the title
+                // skipping h1 headings cuz they become the page title itself.
                 pageNode.children.push(initHeadingNode(node.value, pageNode.depth + node.level - 1));
             }
         });

--- a/src/page.ts
+++ b/src/page.ts
@@ -6,7 +6,7 @@
  */
 
 import * as path from "path";
-import { IHeadingNode, IPageData, IPageNode, isHeadingTag, isTag, slugify } from "./client";
+import { IHeadingNode, IPageData, IPageNode, isHeadingTag, isTag } from "./client";
 
 export type PartialPageData = Pick<IPageData, "absolutePath" | "contentRaw" | "contents" | "metadata">;
 
@@ -18,12 +18,14 @@ export class PageMap {
      * Use this for ingesting rendered blocks.
      */
     public add(data: PartialPageData) {
+        const reference = getReference(data);
         const page: IPageData = {
-            reference: getReference(data),
+            route: reference,
             title: getTitle(data),
+            reference,
             ...data,
         };
-        this.set(page.reference, page);
+        this.set(reference, page);
         return page;
     }
 
@@ -82,11 +84,13 @@ export class PageMap {
 }
 
 function initPageNode({ reference, title }: IPageData, depth: number = 0): IPageNode {
-    return { children: [], depth, reference, title };
+    // NOTE: `route` may be overwritten in MarkdownPlugin based on nesting.
+    return { children: [], depth, reference, route: reference, title };
 }
 
 function initHeadingNode(title: string, depth: number): IHeadingNode {
-    return { depth, reference: slugify(title), title };
+    // NOTE: `route` will be added in MarkdownPlugin.
+    return { depth, title } as IHeadingNode;
 }
 
 function getReference(data: PartialPageData) {

--- a/src/plugins/markdown.ts
+++ b/src/plugins/markdown.ts
@@ -96,6 +96,7 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
             node.route = route;
 
             if (isPageNode(node)) {
+                // node is a page, so it must exist in PageMap.
                 const page = pages.get(node.reference)!;
                 page.route = route;
 

--- a/test/pluginsTests.ts
+++ b/test/pluginsTests.ts
@@ -47,7 +47,7 @@ const TEST_FILES = [
     }, {
         path : "/who/cares/_nav.md",
         read : () => TEST_NAV,
-    }
+    },
 ];
 
 describe("Plugins", () => {

--- a/test/pluginsTests.ts
+++ b/test/pluginsTests.ts
@@ -33,6 +33,10 @@ key: value
 @othertag params
 `;
 
+const TEST_NAV = `
+@page test
+`;
+
 const TEST_FILES = [
     {
         path : "/fancy/absolute/test.css",
@@ -40,7 +44,10 @@ const TEST_FILES = [
     }, {
         path : "/whatever/other/test.md",
         read : () => TEST_MARKDOWN,
-    },
+    }, {
+        path : "/who/cares/_nav.md",
+        read : () => TEST_NAV,
+    }
 ];
 
 describe("Plugins", () => {


### PR DESCRIPTION
- introduce `IHeadingTag extends ITag` with route & level to make rendering headings really easy.
  - Compiler turns all `@#+` tags into `tag: "heading"`, but can't populate `route` yet.
  - Page operates on "page" and "heading" tags (so readable!).
- MarkdownPlugin populates `route` property in pages and nav with fully qualified path to the resource: `path/to/page[.heading]`.
- remove obsolete heading/pageReference options as all slugification happens inside MarkdownPlugin.