### PR TITLE
API refactors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "clean": "rm -rf dist",
     "docs": "pug -O \"$(./cli.js \"./src/**/*\")\" ./theme/index.pug --pretty -o ./docs",
     "demo": "./cli.js 'test/fixtures/**/*'",
+    "lint": "tslint --project .",
+    "lint.fix": "tslint --fix --project . ",
     "test": "mocha --compilers ts:ts-node/register 'test/**/*Tests.ts'",
     "tsc": "tsc --project . && echo 'OK'",
     "watch": "tsc --project . --watch"

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,6 +17,7 @@ export interface INavigable {
 export interface ITag {
     /** Tag name. */
     tag: string;
+
     /** Tag value, exactly as written in source. */
     value: string;
 }
@@ -40,13 +41,13 @@ export type StringOrTag = string | ITag;
  * Type guard to determine if a `contents` node is an `@tag` statement.
  * Optionally tests tag name too, if `tagName` arg is provided.
  */
-export function isTag(node: StringOrTag, tagName?: string): node is ITag {
+export function isTag(node: any, tagName?: string): node is ITag {
     return node != null && (node as ITag).tag !== undefined
         && (tagName === undefined || (node as ITag).tag === tagName);
 }
 
 /** Type guard to deterimine if a `contents` node is an `@#+` heading tag. */
-export function isHeadingTag(node: StringOrTag): node is IHeadingTag {
+export function isHeadingTag(node: any): node is IHeadingTag {
     return isTag(node, "heading");
 }
 
@@ -76,6 +77,7 @@ export interface IMetadata {
      */
     title?: string;
 
+    // Supports arbitrary string keys.
     [key: string]: any;
 }
 
@@ -128,7 +130,7 @@ export interface IPageNode extends IHeadingNode {
 
 /** Type guard for `IPageNode`, useful for its `children` array. */
 export function isPageNode(node: any): node is IPageNode {
-    return (node as IPageNode).children !== undefined;
+    return node != null && (node as IPageNode).children != null;
 }
 
 /** Slugify a string: "Really Cool Heading!" => "really-cool-heading-" */

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,20 +76,26 @@ export interface IMetadata {
 }
 
 /**
+ * The output of `renderBlock` which parses a long form documentation block into
+ * metadata, rendered markdown, and tags.
+ */
+export interface IBlock {
+    /** Raw unmodified contents of source file (excluding the metadata). */
+    contentsRaw: string;
+
+    /** Arbitrary YAML metadata parsed from front matter of source file, if any, or `{}`. */
+    metadata: IMetadata;
+
+    /** Parsed nodes of source file. An array of markdown-rendered HTML strings or `@tag` objects. */
+    contents: StringOrTag[];
+}
+
+/**
  * A single Documentalist page, parsed from a single source file.
  */
-export interface IPageData {
+export interface IPageData extends IBlock {
     /** Absolute path of source file. */
     absolutePath: string;
-
-    /** Raw unmodified contents of source file (excluding the metadata). */
-    contentRaw: string;
-
-    /** Parsed nodes of source file. An array of rendered HTML strings or `@tag` objects. */
-    contents: StringOrTag[];
-
-    /** Arbitrary YAML metadata parsed from front matter of source file */
-    metadata: IMetadata;
 
     /** Unique identifier for addressing this page. */
     reference: string;

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,14 @@
  * repository.
  */
 
+export interface INavigable {
+    /** Fully-qualified route of the heading, which can be used as anchor `href`. */
+    route: string;
+
+    /** Level of heading, from 1-6. Dictates which `<h#>` tag to render. */
+    level: number;
+}
+
 /** Represents a single `@tag <value>` line from a file. */
 export interface ITag {
     /** Tag name. */
@@ -21,12 +29,8 @@ export interface ITag {
  * Heading tags include additional information over regular tags: fully-qualified `route` of the
  * heading (which can be used as anchor `href`), and `level` to determine which `<h#>` tag to use.
  */
-export interface IHeadingTag extends ITag {
+export interface IHeadingTag extends ITag, INavigable {
     tag: "heading";
-    /** Fully-qualified route of the heading, which can be used as anchor `href`. */
-    route: string;
-    /** Level of heading, from 1-6. Dictates which `<h#>` tag to render. */
-    level: number;
 }
 
 /** An entry in `contents` array: either an HTML string or an `@tag`. */
@@ -107,22 +111,19 @@ export interface IPageData extends IBlock {
     title: string;
 }
 
-/** One page entry in a layout tree. */
-export interface ITreeEntry {
-    depth: number;
-    route: string;
+/** An `@#+` tag belongs to a specific page. */
+export interface IHeadingNode extends INavigable {
+    /** Display title of page heading. */
     title: string;
 }
 
 /** A page has ordered children composed of `@#+` and `@page` tags. */
-export interface IPageNode extends ITreeEntry {
-    reference: string;
+export interface IPageNode extends IHeadingNode {
+    /** Ordered list of pages and headings that appear on this page. */
     children: Array<IPageNode | IHeadingNode>;
-}
 
-/** An `@#+` tag belongs to a specific page. */
-// tslint:disable-next-line:no-empty-interface
-export interface IHeadingNode extends ITreeEntry {
+    /** Unique reference of this page, used for retrieval from store. */
+    reference: string;
 }
 
 /** Type guard for `IPageNode`, useful for its `children` array. */

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,6 +5,15 @@
  * repository.
  */
 
+/** Slugify a string: "Really Cool Heading!" => "really-cool-heading-" */
+export function slugify(str: string) {
+    return str.toLowerCase().replace(/[^\w.\/]/g, "-");
+}
+
+/**
+ * The basic components of a navigable resource: a "route" at which it can be accessed and
+ * its depth in the layout hierarchy. Heading tags and hierarchy nodes both extend this interface.
+ */
 export interface INavigable {
     /** Fully-qualified route of the heading, which can be used as anchor `href`. */
     route: string;
@@ -12,6 +21,10 @@ export interface INavigable {
     /** Level of heading, from 1-6. Dictates which `<h#>` tag to render. */
     level: number;
 }
+
+/*
+@TAGS
+*/
 
 /** Represents a single `@tag <value>` line from a file. */
 export interface ITag {
@@ -51,6 +64,10 @@ export function isHeadingTag(node: any): node is IHeadingTag {
     return isTag(node, "heading");
 }
 
+/*
+PAGE DATA
+*/
+
 /**
  * Metadata is parsed from YAML front matter in files and can contain arbitrary data.
  * A few keys are understood by Documentalist and, if defined in front matter,
@@ -86,14 +103,14 @@ export interface IMetadata {
  * metadata, rendered markdown, and tags.
  */
 export interface IBlock {
+    /** Parsed nodes of source file. An array of markdown-rendered HTML strings or `@tag` objects. */
+    contents: StringOrTag[];
+
     /** Raw unmodified contents of source file (excluding the metadata). */
     contentsRaw: string;
 
     /** Arbitrary YAML metadata parsed from front matter of source file, if any, or `{}`. */
     metadata: IMetadata;
-
-    /** Parsed nodes of source file. An array of markdown-rendered HTML strings or `@tag` objects. */
-    contents: StringOrTag[];
 }
 
 /**
@@ -113,6 +130,10 @@ export interface IPageData extends IBlock {
     title: string;
 }
 
+/*
+LAYOUT HIERARCHY NODES
+*/
+
 /** An `@#+` tag belongs to a specific page. */
 export interface IHeadingNode extends INavigable {
     /** Display title of page heading. */
@@ -131,9 +152,4 @@ export interface IPageNode extends IHeadingNode {
 /** Type guard for `IPageNode`, useful for its `children` array. */
 export function isPageNode(node: any): node is IPageNode {
     return node != null && (node as IPageNode).children != null;
-}
-
-/** Slugify a string: "Really Cool Heading!" => "really-cool-heading-" */
-export function slugify(str: string) {
-    return str.toLowerCase().replace(/[^\w.\/]/g, "-");
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -39,9 +39,9 @@ export class Compiler implements ICompiler {
     }
 
     public renderBlock = (blockContent: string, reservedTagWords = RESERVED_WORDS): IBlock => {
-        const { content, metadata } = this.extractMetadata(blockContent);
-        const renderedContent = this.renderContents(content, reservedTagWords);
-        return { content, metadata, renderedContent };
+        const { contentsRaw, metadata } = this.extractMetadata(blockContent);
+        const contents = this.renderContents(contentsRaw, reservedTagWords);
+        return { contents, contentsRaw, metadata };
     }
 
     public renderMarkdown = (markdown: string) => marked(markdown, this.markedOptions);
@@ -65,11 +65,11 @@ export class Compiler implements ICompiler {
     private extractMetadata(text: string) {
         const match = METADATA_REGEX.exec(text);
         if (match === null) {
-            return { content: text, metadata: {} };
+            return { contentsRaw: text, metadata: {} };
         }
 
-        const content = text.substr(match[0].length);
-        return { content, metadata: yaml.load(match[1]) || {} };
+        const contentsRaw = text.substr(match[0].length);
+        return { contentsRaw, metadata: yaml.load(match[1]) || {} };
     }
 
     /**

--- a/src/page.ts
+++ b/src/page.ts
@@ -6,9 +6,9 @@
  */
 
 import * as path from "path";
-import { IHeadingNode, IPageData, IPageNode, isHeadingTag, isTag } from "./client";
+import { IBlock, IHeadingNode, IPageData, IPageNode, isHeadingTag, isTag } from "./client";
 
-export type PartialPageData = Pick<IPageData, "absolutePath" | "contentsRaw" | "contents" | "metadata">;
+export type PartialPageData = Pick<IPageData, "absolutePath" | keyof IBlock>;
 
 export class PageMap {
     private pages: Map<string, IPageData> = new Map();

--- a/src/page.ts
+++ b/src/page.ts
@@ -76,21 +76,21 @@ export class PageMap {
                 pageNode.children.push(this.toTree(node.value, depth + 1));
             } else if (isHeadingTag(node) && node.level > 1) {
                 // skipping h1 headings cuz they become the page title itself.
-                pageNode.children.push(initHeadingNode(node.value, pageNode.depth + node.level - 1));
+                pageNode.children.push(initHeadingNode(node.value, pageNode.level + node.level - 1));
             }
         });
         return pageNode;
     }
 }
 
-function initPageNode({ reference, title }: IPageData, depth: number = 0): IPageNode {
+function initPageNode({ reference, title }: IPageData, level: number = 0): IPageNode {
     // NOTE: `route` may be overwritten in MarkdownPlugin based on nesting.
-    return { children: [], depth, reference, route: reference, title };
+    return { children: [], level, reference, route: reference, title };
 }
 
-function initHeadingNode(title: string, depth: number): IHeadingNode {
+function initHeadingNode(title: string, level: number): IHeadingNode {
     // NOTE: `route` will be added in MarkdownPlugin.
-    return { depth, title } as IHeadingNode;
+    return { title, level } as IHeadingNode;
 }
 
 function getReference(data: PartialPageData) {

--- a/src/page.ts
+++ b/src/page.ts
@@ -8,7 +8,7 @@
 import * as path from "path";
 import { IHeadingNode, IPageData, IPageNode, isHeadingTag, isTag } from "./client";
 
-export type PartialPageData = Pick<IPageData, "absolutePath" | "contentRaw" | "contents" | "metadata">;
+export type PartialPageData = Pick<IPageData, "absolutePath" | "contentsRaw" | "contents" | "metadata">;
 
 export class PageMap {
     private pages: Map<string, IPageData> = new Map();

--- a/src/plugins/markdown.ts
+++ b/src/plugins/markdown.ts
@@ -61,15 +61,10 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
     private buildPageMap(markdownFiles: IFile[], { renderBlock }: ICompiler) {
         const pageStore: PageMap = new PageMap();
         markdownFiles
-            .map((file) => {
-                const { content, metadata, renderedContent } = renderBlock(file.read());
-                return pageStore.add({
-                    absolutePath: file.path,
-                    contentRaw: content,
-                    contents: renderedContent,
-                    metadata,
-                });
-            })
+            .map((file) => pageStore.add({
+                absolutePath: file.path,
+                ...renderBlock(file.read()),
+            }))
             .map((page) => {
                 // using `reduce` so we can add one or many entries for each node
                 page.contents = page.contents.reduce((array, content) => {

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -5,9 +5,9 @@
  * repository.
  */
 
-import { StringOrTag } from "../client";
+import { IBlock, StringOrTag } from "../client";
 
-export { StringOrTag };
+export { IBlock, StringOrTag };
 
 /**
  * Abstract representation of a file, containing absolute path and synchronous `read` operation.
@@ -15,27 +15,6 @@ export { StringOrTag };
 export interface IFile {
     path: string;
     read: () => string;
-}
-
-/**
- * The output of `renderBlock` which parses a long form documentation block into
- * metadata, rendered markdown, and tags.
- */
-export interface IBlock {
-    /**
-     * The original string content block.
-     */
-    content: string;
-
-    /**
-     * Parsed YAML front matter (if any) or {}.
-     */
-    metadata: any;
-
-    /**
-     * An array of markdown-rendered HTML or tags.
-     */
-    renderedContent: StringOrTag[];
 }
 
 /**

--- a/test/compilerTests.ts
+++ b/test/compilerTests.ts
@@ -17,26 +17,26 @@ describe("Compiler", () => {
         const MARKDOWN = "# Title\nbody body body";
         const OBJECT = { hello: "world", size: 1000 };
 
-        it("extracts contents and parses metadata", () => {
+        it("extracts contentsRaw and parses metadata", () => {
             const data = API.renderBlock(METADATA + MARKDOWN);
-            assert.strictEqual(data.content, MARKDOWN);
+            assert.strictEqual(data.contentsRaw, MARKDOWN);
             assert.deepEqual(data.metadata, OBJECT);
         });
 
         it("supports empty metadata block", () => {
             const data = API.renderBlock("---\n---\n" + MARKDOWN);
-            assert.strictEqual(data.content, MARKDOWN);
+            assert.strictEqual(data.contentsRaw, MARKDOWN);
             assert.deepEqual(data.metadata, {});
         });
 
         it("metadata block is optional", () => {
             const data = API.renderBlock(MARKDOWN);
-            assert.strictEqual(data.content, MARKDOWN);
+            assert.strictEqual(data.contentsRaw, MARKDOWN);
             assert.deepEqual(data.metadata, {});
         });
     });
 
-    describe("renderedContent", () => {
+    describe("rendered contents", () => {
         const FILE = `
 # Title
 description
@@ -45,21 +45,21 @@ more description
         `;
 
         it("returns a single-element array for string without @tags", () => {
-            const { renderedContent } = API.renderBlock("simple string");
-            assert.deepEqual(renderedContent, ["<p>simple string</p>\n"]);
+            const { contents } = API.renderBlock("simple string");
+            assert.deepEqual(contents, ["<p>simple string</p>\n"]);
         });
 
         it("converts @tag to object in array", () => {
-            const { renderedContent } = API.renderBlock(FILE);
-            assert.equal(renderedContent.length, 3);
-            assert.deepEqual(renderedContent[1], { tag: "interface", value: "IButtonProps" });
+            const { contents } = API.renderBlock(FILE);
+            assert.equal(contents.length, 3);
+            assert.deepEqual(contents[1], { tag: "interface", value: "IButtonProps" });
         });
 
         it("reservedWords will ignore matching @tag", () => {
-            const { renderedContent } = API.renderBlock(FILE, ["interface"]);
-            assert.equal(renderedContent.length, 3);
+            const { contents } = API.renderBlock(FILE, ["interface"]);
+            assert.equal(contents.length, 3);
             // reserved @tag is emitted as separate string cuz it's still split by regex
-            assert.deepEqual(renderedContent[1], "<p>@interface IButtonProps</p>\n");
+            assert.deepEqual(contents[1], "<p>@interface IButtonProps</p>\n");
         });
 
     });


### PR DESCRIPTION
- `IPageData` extends `IBlock`, compiler methods also speak `IBlock`
  - this reduces the naming surface area because `contents` always refers to rendered `StringOrTag[]` and `contentsRaw` is always a string.
- new interface `INavigable` for route & level used in `IHeadingTag` & `IHeadingNode`
- `IPageNode` extends `IHeadingNode` for maximal reuse (also rename depth &rarr; level)
- type guards take `any` arg & check existence first