### PR TITLE
options options options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,26 @@
 
 - `.md` files for longform documentation and overall structure
 - `.ts`, `.tsx` files for JSDoc comments on interfaces in TypeScript source code
-- `.css`, `.scss` files for comments on CSS selectors
+- `.css`, `.less`, `.scss` files for comments on CSS selectors
+
+With the JavaScript API, nothing comes for free. All plugins must be registered with `.use()`.
 
 ```js
-const { Documentalist } = require("documentalist");
+const { Documentalist, MarkdownPlugin } = require("documentalist");
 const { writeFileSync } = require("fs");
 
-const dm = new Documentalist();
-const docs = dm.documentGlobs("src/**/*");
+const docs = new Documentalist()
+  .use(".md", new MarkdownPlugin())
+  .documentGlobs("src/**/*");
 
 writeFileSync("docs.json", JSON.stringify(docs, null, 2));
+```
+
+With the CLI, the Markdown and Typescript plugins are enabled by default.
+The CSS plugin can be enabled with `--css`.
+
+```sh
+documentalist "src/**/*" --css --no-ts > docs.json
 ```
 
 # License

--- a/src/__tests__/compiler.test.ts
+++ b/src/__tests__/compiler.test.ts
@@ -80,9 +80,10 @@ describe("Compiler", () => {
 
         it("reservedWords will ignore matching @tag", () => {
             const { contents } = API.renderBlock(FILE, ["interface"]);
-            expect(contents).toHaveLength(3);
-            // reserved @tag is emitted as separate string cuz it's still split by regex
-            expect(contents[1]).toEqual("<p>@interface IButtonProps</p>\n");
+            // only one string (reserved @word does not get split to its own entry)
+            expect(contents).toHaveLength(1);
+            // @tag value comes out exactly as written in source, on its own line
+            expect((contents[0] as string).split("\n")).toContain("@interface IButtonProps");
         });
 
     });

--- a/src/__tests__/markdown.test.ts
+++ b/src/__tests__/markdown.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { Documentalist, ITag } from "../index";
+import { MarkdownPlugin } from "../plugins/markdown";
 
 const TEST_MARKDOWN = `---
 key: value
@@ -33,8 +34,11 @@ const TEST_FILES = [
 ];
 
 describe("Plugins", () => {
+    const dm = Documentalist.create()
+        .use(".md", new MarkdownPlugin());
+
     it("can document Markdown files", async () => {
-        const docs = await Documentalist.create().documentFiles(TEST_FILES);
+        const docs = await dm.documentFiles(TEST_FILES);
         const page = docs.pages["test"];
         expect(page).toBeDefined();
         expect(page.metadata["key"]).toBe("value");

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,6 +1,5 @@
 import * as yaml from "js-yaml";
 import * as marked from "marked";
-
 import { IHeadingTag } from "./client";
 import { IBlock, ICompiler, StringOrTag } from "./plugins/plugin";
 
@@ -16,19 +15,13 @@ const METADATA_REGEX = /^---\n?((?:.|\n)*)\n---\n/;
 const TAG_REGEX = /^@(\S+)(?:\s+([^\n]+))?$/;
 const TAG_SPLIT_REGEX = /^(@\S+(?:\s+[^\n]+)?)$/gm;
 
-/**
- * Ignored `@tag` names. Some languages already support `@tags`, so to separate
- * Documentalist tags, we use these default reserved words to avoid conflicts.
- *
- * Plugins may define their own reserved words when calling the `renderBlock`
- * method.
- */
-const RESERVED_WORDS = [
-    "import",
-];
+export interface ICompilerOptions {
+    markdown?: MarkedOptions;
+    reservedTags?: string[];
+}
 
 export class Compiler implements ICompiler {
-    public constructor(private markedOptions: MarkedOptions) {
+    public constructor(private options: ICompilerOptions) {
     }
 
     public objectify<T>(array: T[], getKey: (item: T) => string) {
@@ -38,20 +31,20 @@ export class Compiler implements ICompiler {
         }, {} as { [key: string]: T });
     }
 
-    public renderBlock = (blockContent: string, reservedTagWords = RESERVED_WORDS): IBlock => {
+    public renderBlock = (blockContent: string, reservedTagWords = this.options.reservedTags): IBlock => {
         const { contentsRaw, metadata } = this.extractMetadata(blockContent);
         const contents = this.renderContents(contentsRaw, reservedTagWords);
         return { contents, contentsRaw, metadata };
     }
 
-    public renderMarkdown = (markdown: string) => marked(markdown, this.markedOptions);
+    public renderMarkdown = (markdown: string) => marked(markdown, this.options.markdown);
 
     /**
      * Converts the content string into an array of `ContentNode`s. If the
      * `contents` option is `html`, the string nodes will also be rendered with
      * markdown.
      */
-    private renderContents(content: string, reservedTagWords: string[]) {
+    private renderContents(content: string, reservedTagWords?: string[]) {
         const splitContents = this.parseTags(content, reservedTagWords);
         return splitContents
             .map((node) => typeof node === "string" ? this.renderMarkdown(node) : node)
@@ -77,20 +70,28 @@ export class Compiler implements ICompiler {
      * `@tag`. You may prevent this splitting by specifying an array of reserved
      * tag names.
      */
-    private parseTags(content: string, reservedWords: string[]) {
-        return content.split(TAG_SPLIT_REGEX).map((str): StringOrTag => {
+    private parseTags(content: string, reservedWords: string[] = []) {
+        // using reduce so we can squash consecutive strings (<= 1 entry per iteration)
+        return content.split(TAG_SPLIT_REGEX).reduce((arr, str) => {
             const match = TAG_REGEX.exec(str);
             if (match === null || reservedWords.indexOf(match[1]) >= 0) {
-                return str;
-            }
-            const tag = match[1];
-            const value = match[2];
-            if (/#+/.test(tag)) {
-                // NOTE: not enough information to populate `route` field yet
-                return { tag: "heading", value, level: tag.length } as IHeadingTag;
+                if (typeof arr[arr.length - 1] === "string") {
+                    // merge consecutive strings to avoid breaking up code blocks
+                    arr[arr.length - 1] += str;
+                } else {
+                    arr.push(str);
+                }
             } else {
-                return { tag, value };
+                const tag = match[1];
+                const value = match[2];
+                if (/#+/.test(tag)) {
+                    // NOTE: not enough information to populate `route` field yet
+                    arr.push({ tag: "heading", value, level: tag.length } as IHeadingTag);
+                } else {
+                    arr.push({ tag, value });
+                }
             }
-        });
+            return arr;
+        }, [] as StringOrTag[]);
     }
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -16,7 +16,14 @@ const TAG_REGEX = /^@(\S+)(?:\s+([^\n]+))?$/;
 const TAG_SPLIT_REGEX = /^(@\S+(?:\s+[^\n]+)?)$/gm;
 
 export interface ICompilerOptions {
+    /** Options for markdown rendering. See https://github.com/chjj/marked#options-1. */
     markdown?: MarkedOptions;
+
+    /**
+     * Reserved @tags that should be preserved in the contents string.
+     * A common use case is allowing specific code constructs, like `@Decorator` names.
+     * Do not include the `@` prefix in the strings.
+     */
     reservedTags?: string[];
 }
 

--- a/src/documentalist.ts
+++ b/src/documentalist.ts
@@ -8,7 +8,7 @@
 import * as fs from "fs";
 import * as glob from "glob";
 import * as path from "path";
-import { Compiler } from "./compiler";
+import { Compiler, ICompilerOptions } from "./compiler";
 import {
     IFile,
     IMarkdownPluginData,
@@ -67,14 +67,14 @@ export interface IPluginEntry<T> {
 }
 
 export class Documentalist<T> implements IApi<T> {
-    public static create(markedOptions?: MarkedOptions): IApi<IMarkdownPluginData & ITypescriptPluginData> {
-        return new Documentalist(markedOptions, [])
+    public static create(options?: ICompilerOptions): IApi<IMarkdownPluginData & ITypescriptPluginData> {
+        return new Documentalist(options, [])
             .use(/\.md$/, new MarkdownPlugin())
             .use(/\.tsx?$/, new TypescriptPlugin());
     }
 
     constructor(
-        private markedOptions: MarkedOptions = {},
+        private options: ICompilerOptions = {},
         private plugins: Array<IPluginEntry<T>> = [],
     ) {
     }
@@ -85,11 +85,11 @@ export class Documentalist<T> implements IApi<T> {
         }
 
         const newPlugins = [...this.plugins, { pattern, plugin } as IPluginEntry<T & P>];
-        return new Documentalist(this.markedOptions, newPlugins);
+        return new Documentalist(this.options, newPlugins);
     }
 
     public clearPlugins(): IApi<{}> {
-        return new Documentalist<{}>(this.markedOptions, []);
+        return new Documentalist<{}>(this.options, []);
     }
 
     public async documentGlobs(...filesGlobs: string[]) {
@@ -98,7 +98,7 @@ export class Documentalist<T> implements IApi<T> {
     }
 
     public async documentFiles(files: IFile[]) {
-        const compiler = new Compiler(this.markedOptions);
+        const compiler = new Compiler(this.options);
         const documentation = {} as T;
         for (const { pattern, plugin } of this.plugins) {
             const pluginFiles = files.filter((f) => pattern.test(f.path));

--- a/src/documentalist.ts
+++ b/src/documentalist.ts
@@ -68,14 +68,15 @@ export interface IPluginEntry<T> {
 
 export class Documentalist<T> implements IApi<T> {
     public static create(markedOptions?: MarkedOptions): IApi<IMarkdownPluginData & ITypescriptPluginData> {
-        return new Documentalist([], markedOptions)
+        return new Documentalist(markedOptions, [])
             .use(/\.md$/, new MarkdownPlugin())
             .use(/\.tsx?$/, new TypescriptPlugin());
     }
 
     constructor(
+        private markedOptions: MarkedOptions = {},
         private plugins: Array<IPluginEntry<T>> = [],
-        private markedOptions: MarkedOptions = {}) {
+    ) {
     }
 
     public use<P>(pattern: RegExp | string, plugin: IPlugin<P>): IApi<T & P> {
@@ -84,11 +85,11 @@ export class Documentalist<T> implements IApi<T> {
         }
 
         const newPlugins = [...this.plugins, { pattern, plugin } as IPluginEntry<T & P>];
-        return new Documentalist(newPlugins, this.markedOptions);
+        return new Documentalist(this.markedOptions, newPlugins);
     }
 
     public clearPlugins(): IApi<{}> {
-        return new Documentalist<{}>([], this.markedOptions);
+        return new Documentalist<{}>(this.markedOptions, []);
     }
 
     public async documentGlobs(...filesGlobs: string[]) {

--- a/src/documentalist.ts
+++ b/src/documentalist.ts
@@ -9,14 +9,7 @@ import * as fs from "fs";
 import * as glob from "glob";
 import * as path from "path";
 import { Compiler, ICompilerOptions } from "./compiler";
-import {
-    IFile,
-    IMarkdownPluginData,
-    IPlugin,
-    ITypescriptPluginData,
-    MarkdownPlugin,
-    TypescriptPlugin,
-} from "./plugins";
+import { IFile, IPlugin } from "./plugins";
 
 export interface IApi<T> {
     /**
@@ -67,10 +60,8 @@ export interface IPluginEntry<T> {
 }
 
 export class Documentalist<T> implements IApi<T> {
-    public static create(options?: ICompilerOptions): IApi<IMarkdownPluginData & ITypescriptPluginData> {
-        return new Documentalist(options, [])
-            .use(/\.md$/, new MarkdownPlugin())
-            .use(/\.tsx?$/, new TypescriptPlugin());
+    public static create(options?: ICompilerOptions): IApi<{}> {
+        return new Documentalist(options, []);
     }
 
     constructor(

--- a/src/plugins/typescript.ts
+++ b/src/plugins/typescript.ts
@@ -33,7 +33,16 @@ export interface ITypescriptPluginData {
 
 export class TypescriptPlugin implements IPlugin<ITypescriptPluginData> {
     public constructor(
+        /**
+         * Options to `ts-quick-docs`, mostly for customizing which symbols appear in the output.
+         */
         private options: IDocumentationOptions = {},
+
+        /**
+         * Compiler options for Typescript program used to "read" your typings.
+         * (This is distinct from whatever options you need to build your typings.)
+         * If omitted, the default compiler options are used.
+         */
         // HACK: using any to avoid duplicate typings issue with ts.CompilerOptions
         private compilerOptions: any = {},
     ) {}


### PR DESCRIPTION
add options to compiler and typescript plugin. documentalist passes its options straight to compiler.

swap order of `Documentalist` constructor args so no need for empty plugins array every time.

⚠️ remove default plugins from `Documentalist.create()` because they have options that will want to be set.