### PR TITLE
Isolate client typings

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -329,78 +329,6 @@ this representation.</p>
         </div>
       </div>
   </div>
-  <div class="hidden" data-route="IPageData">
-    <h2>IPageData</h2>
-      <div class="interface-block" id="IPageData"><p>A single Documentalist page, parsed from a single source file.</p>
-
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">reference</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Unique identifier for addressing this page. </p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">route</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Fully qualified route to this page: slash-separated references of all parent pages. </p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">title</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Human-friendly title of this page. </p>
-
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="IHeadingNode">
-    <h2>IHeadingNode</h2>
-      <div class="interface-block" id="IHeadingNode"><p>An <code>@#+</code> tag belongs to a specific page. </p>
-
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">title</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Display title of page heading. </p>
-
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="IPageNode">
-    <h2>IPageNode</h2>
-      <div class="interface-block" id="IPageNode"><p>A page has ordered children composed of <code>@#+</code> and <code>@page</code> tags. </p>
-
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">children</td>
-              <td class="prop-type" valign="top">
-                <pre>(IPageNode | IHeadingNode)[]</pre><p>Ordered list of pages and headings that appear on this page. </p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">reference</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Unique reference of this page, used for retrieval from store. </p>
-
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
   <div class="hidden" data-route="INavigable">
     <h2>INavigable</h2>
       <div class="interface-block" id="INavigable"><p>The basic components of a navigable resource: a &quot;route&quot; at which it can be accessed and
@@ -527,6 +455,78 @@ metadata, rendered markdown, and tags.</p>
               <td class="prop-name" valign="top">metadata</td>
               <td class="prop-type" valign="top">
                 <pre>IMetadata</pre><p>Arbitrary YAML metadata parsed from front matter of source file, if any, or <code>{}</code>. </p>
+
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="IPageData">
+    <h2>IPageData</h2>
+      <div class="interface-block" id="IPageData"><p>A single Documentalist page, parsed from a single source file.</p>
+
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">reference</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Unique identifier for addressing this page. </p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">route</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Fully qualified route to this page: slash-separated references of all parent pages. </p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">title</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Human-friendly title of this page. </p>
+
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="IHeadingNode">
+    <h2>IHeadingNode</h2>
+      <div class="interface-block" id="IHeadingNode"><p>An <code>@#+</code> tag belongs to a specific page. </p>
+
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">title</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Display title of page heading. </p>
+
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="IPageNode">
+    <h2>IPageNode</h2>
+      <div class="interface-block" id="IPageNode"><p>A page has ordered children composed of <code>@#+</code> and <code>@page</code> tags. </p>
+
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">children</td>
+              <td class="prop-type" valign="top">
+                <pre>(IPageNode | IHeadingNode)[]</pre><p>Ordered list of pages and headings that appear on this page. </p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">reference</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Unique reference of this page, used for retrieval from store. </p>
 
               </td>
             </tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -126,6 +126,281 @@ supplied pattern.</p>
 <p>Documentalist uses a plugin architecture to support arbitrary file types.</p>
 
   </div>
+  <div class="hidden" data-route="IKssModifier">
+    <h2>IKssModifier</h2>
+      <div class="interface-block" id="IKssModifier"><p>Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
+Licensed under the BSD-3 License as modified (the “License”); you may obtain
+a copy of the license in the LICENSE and PATENTS files in the root of this
+repository.
+A single modifier for an example. </p>
+
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">documentation</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre>
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">name</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="IKssExample">
+    <h2>IKssExample</h2>
+      <div class="interface-block" id="IKssExample"><p>A markup/modifiers example parsed from a KSS comment block.</p>
+
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">documentation</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Raw documentation string. </p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">markup</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Raw HTML markup for example with <code>{{.modifier}}</code> templates,
+to be used to render the markup for each modifier.</p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">markupHtml</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Syntax-highlighted version of the markup HTML, to be used
+for rendering the markup itself with pretty colors.</p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">modifiers</td>
+              <td class="prop-type" valign="top">
+                <pre>IKssModifier[]</pre><p>Array of modifiers supported by HTML markup. </p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">reference</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Unique reference for addressing this example. </p>
+
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="IKssPluginData">
+    <h2>IKssPluginData</h2>
+      <div class="interface-block" id="IKssPluginData">
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">css</td>
+              <td class="prop-type" valign="top">
+                <pre>{ [reference: string]: IKssExample; }</pre>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="IMarkdownPluginData">
+    <h2>IMarkdownPluginData</h2>
+      <div class="interface-block" id="IMarkdownPluginData">
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">nav</td>
+              <td class="prop-type" valign="top">
+                <pre>IPageNode[]</pre><p>An ordered, nested, multi-rooted tree describing the navigation layout
+of all the pages and their headings. Uses <code>@page</code> and <code>@#+</code> tags to build
+this representation.</p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">pages</td>
+              <td class="prop-type" valign="top">
+                <pre>{ [reference: string]: IPageData; }</pre><p>A map of page reference to data. </p>
+
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="ITsDocEntry">
+    <h2>ITsDocEntry</h2>
+      <div class="interface-block" id="ITsDocEntry">
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">documentation</td>
+              <td class="prop-type" valign="top">
+                <pre>IBlock</pre>
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">fileName</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre>
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">name</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre>
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">tags</td>
+              <td class="prop-type" valign="top">
+                <pre>IJsDocTags</pre>
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">type</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="ITsPropertyEntry">
+    <h2>ITsPropertyEntry</h2>
+      <div class="interface-block" id="ITsPropertyEntry">
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">optional</td>
+              <td class="prop-type" valign="top">
+                <pre>boolean</pre>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="ITsInterfaceEntry">
+    <h2>ITsInterfaceEntry</h2>
+      <div class="interface-block" id="ITsInterfaceEntry">
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">extends</td>
+              <td class="prop-type" valign="top">
+                <pre>string[]</pre>
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">properties</td>
+              <td class="prop-type" valign="top">
+                <pre>ITsPropertyEntry[]</pre>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="ITypescriptPluginData">
+    <h2>ITypescriptPluginData</h2>
+      <div class="interface-block" id="ITypescriptPluginData">
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">ts</td>
+              <td class="prop-type" valign="top">
+                <pre>{ [name: string]: ITsInterfaceEntry; }</pre>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="IPageData">
+    <h2>IPageData</h2>
+      <div class="interface-block" id="IPageData"><p>A single Documentalist page, parsed from a single source file.</p>
+
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">reference</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Unique identifier for addressing this page. </p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">route</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Fully qualified route to this page: slash-separated references of all parent pages. </p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">title</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Human-friendly title of this page. </p>
+
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="IHeadingNode">
+    <h2>IHeadingNode</h2>
+      <div class="interface-block" id="IHeadingNode"><p>An <code>@#+</code> tag belongs to a specific page. </p>
+
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">title</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Display title of page heading. </p>
+
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
+  <div class="hidden" data-route="IPageNode">
+    <h2>IPageNode</h2>
+      <div class="interface-block" id="IPageNode"><p>A page has ordered children composed of <code>@#+</code> and <code>@page</code> tags. </p>
+
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">children</td>
+              <td class="prop-type" valign="top">
+                <pre>(IPageNode | IHeadingNode)[]</pre><p>Ordered list of pages and headings that appear on this page. </p>
+
+              </td>
+            </tr>
+            <tr>
+              <td class="prop-name" valign="top">reference</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Unique reference of this page, used for retrieval from store. </p>
+
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
   <div class="hidden" data-route="INavigable">
     <h2>INavigable</h2>
       <div class="interface-block" id="INavigable"><p>The basic components of a navigable resource: a &quot;route&quot; at which it can be accessed and
@@ -259,78 +534,6 @@ metadata, rendered markdown, and tags.</p>
         </div>
       </div>
   </div>
-  <div class="hidden" data-route="IPageData">
-    <h2>IPageData</h2>
-      <div class="interface-block" id="IPageData"><p>A single Documentalist page, parsed from a single source file.</p>
-
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">reference</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Unique identifier for addressing this page. </p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">route</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Fully qualified route to this page: slash-separated references of all parent pages. </p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">title</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Human-friendly title of this page. </p>
-
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="IHeadingNode">
-    <h2>IHeadingNode</h2>
-      <div class="interface-block" id="IHeadingNode"><p>An <code>@#+</code> tag belongs to a specific page. </p>
-
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">title</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Display title of page heading. </p>
-
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="IPageNode">
-    <h2>IPageNode</h2>
-      <div class="interface-block" id="IPageNode"><p>A page has ordered children composed of <code>@#+</code> and <code>@page</code> tags. </p>
-
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">children</td>
-              <td class="prop-type" valign="top">
-                <pre>(IPageNode | IHeadingNode)[]</pre><p>Ordered list of pages and headings that appear on this page. </p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">reference</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Unique reference of this page, used for retrieval from store. </p>
-
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
   <div class="hidden" data-route="IFile">
     <h2>IFile</h2>
       <div class="interface-block" id="IFile"><p>Abstract representation of a file, containing absolute path and synchronous <code>read</code> operation.</p>
@@ -405,6 +608,22 @@ is.</p>
         </div>
       </div>
   </div>
+  <div class="hidden" data-route="IMarkdownPluginOptions">
+    <h2>IMarkdownPluginOptions</h2>
+      <div class="interface-block" id="IMarkdownPluginOptions">
+        <div class="interface-properties">
+          <table>
+            <tr>
+              <td class="prop-name" valign="top">navPage</td>
+              <td class="prop-type" valign="top">
+                <pre>string</pre><p>Page reference that lists the nav roots.</p>
+
+              </td>
+            </tr>
+          </table>
+        </div>
+      </div>
+  </div>
   <div class="hidden" data-route="ICompilerOptions">
     <h2>ICompilerOptions</h2>
       <div class="interface-block" id="ICompilerOptions">
@@ -424,221 +643,6 @@ is.</p>
 A common use case is allowing specific code constructs, like <code>@Decorator</code> names.
 Do not include the <code>@</code> prefix in the strings.</p>
 
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="IKssModifier">
-    <h2>IKssModifier</h2>
-      <div class="interface-block" id="IKssModifier"><p>A single modifier for an example. </p>
-
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">documentation</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre>
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">name</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre>
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="IKssExample">
-    <h2>IKssExample</h2>
-      <div class="interface-block" id="IKssExample"><p>A markup/modifiers example parsed from a KSS comment block.</p>
-
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">documentation</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Raw documentation string. </p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">markup</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Raw HTML markup for example with <code>{{.modifier}}</code> templates,
-to be used to render the markup for each modifier.</p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">markupHtml</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Syntax-highlighted version of the markup HTML, to be used
-for rendering the markup itself with pretty colors.</p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">modifiers</td>
-              <td class="prop-type" valign="top">
-                <pre>IKssModifier[]</pre><p>Array of modifiers supported by HTML markup. </p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">reference</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Unique reference for addressing this example. </p>
-
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="IKssPluginData">
-    <h2>IKssPluginData</h2>
-      <div class="interface-block" id="IKssPluginData">
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">css</td>
-              <td class="prop-type" valign="top">
-                <pre>{ [reference: string]: IKssExample; }</pre>
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="IMarkdownPluginData">
-    <h2>IMarkdownPluginData</h2>
-      <div class="interface-block" id="IMarkdownPluginData">
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">nav</td>
-              <td class="prop-type" valign="top">
-                <pre>IPageNode[]</pre><p>An ordered, nested, multi-rooted tree describing the navigation layout
-of all the pages and their headings. Uses <code>@page</code> and <code>@#+</code> tags to build
-this representation.</p>
-
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">pages</td>
-              <td class="prop-type" valign="top">
-                <pre>{ [reference: string]: IPageData; }</pre><p>A map of page reference to data. </p>
-
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="IMarkdownPluginOptions">
-    <h2>IMarkdownPluginOptions</h2>
-      <div class="interface-block" id="IMarkdownPluginOptions">
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">navPage</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre><p>Page reference that lists the nav roots.</p>
-
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="ITsDocEntry">
-    <h2>ITsDocEntry</h2>
-      <div class="interface-block" id="ITsDocEntry">
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">documentation</td>
-              <td class="prop-type" valign="top">
-                <pre>IBlock</pre>
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">fileName</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre>
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">name</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre>
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">tags</td>
-              <td class="prop-type" valign="top">
-                <pre>IJsDocTags</pre>
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">type</td>
-              <td class="prop-type" valign="top">
-                <pre>string</pre>
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="ITsPropertyEntry">
-    <h2>ITsPropertyEntry</h2>
-      <div class="interface-block" id="ITsPropertyEntry">
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">optional</td>
-              <td class="prop-type" valign="top">
-                <pre>boolean</pre>
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="ITsInterfaceEntry">
-    <h2>ITsInterfaceEntry</h2>
-      <div class="interface-block" id="ITsInterfaceEntry">
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">extends</td>
-              <td class="prop-type" valign="top">
-                <pre>string[]</pre>
-              </td>
-            </tr>
-            <tr>
-              <td class="prop-name" valign="top">properties</td>
-              <td class="prop-type" valign="top">
-                <pre>ITsPropertyEntry[]</pre>
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-  </div>
-  <div class="hidden" data-route="ITypescriptPluginData">
-    <h2>ITypescriptPluginData</h2>
-      <div class="interface-block" id="ITypescriptPluginData">
-        <div class="interface-properties">
-          <table>
-            <tr>
-              <td class="prop-name" valign="top">ts</td>
-              <td class="prop-type" valign="top">
-                <pre>{ [name: string]: ITsInterfaceEntry; }</pre>
               </td>
             </tr>
           </table>

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,35 +11,6 @@ export * from "./typescript";
 export * from "./utils";
 
 /**
- * A single Documentalist page, parsed from a single source file.
- */
-export interface IPageData extends IBlock {
-    /** Unique identifier for addressing this page. */
-    reference: string;
-
-    /** Fully qualified route to this page: slash-separated references of all parent pages. */
-    route: string;
-
-    /** Human-friendly title of this page. */
-    title: string;
-}
-
-/** An `@#+` tag belongs to a specific page. */
-export interface IHeadingNode extends INavigable {
-    /** Display title of page heading. */
-    title: string;
-}
-
-/** A page has ordered children composed of `@#+` and `@page` tags. */
-export interface IPageNode extends IHeadingNode {
-    /** Ordered list of pages and headings that appear on this page. */
-    children: Array<IPageNode | IHeadingNode>;
-
-    /** Unique reference of this page, used for retrieval from store. */
-    reference: string;
-}
-
-/**
  * The basic components of a navigable resource: a "route" at which it can be accessed and
  * its depth in the layout hierarchy. Heading tags and hierarchy nodes both extend this interface.
  */
@@ -118,4 +89,33 @@ export interface IBlock {
 
     /** Arbitrary YAML metadata parsed from front matter of source file, if any, or `{}`. */
     metadata: IMetadata;
+}
+
+/**
+ * A single Documentalist page, parsed from a single source file.
+ */
+export interface IPageData extends IBlock {
+    /** Unique identifier for addressing this page. */
+    reference: string;
+
+    /** Fully qualified route to this page: slash-separated references of all parent pages. */
+    route: string;
+
+    /** Human-friendly title of this page. */
+    title: string;
+}
+
+/** An `@#+` tag belongs to a specific page. */
+export interface IHeadingNode extends INavigable {
+    /** Display title of page heading. */
+    title: string;
+}
+
+/** A page has ordered children composed of `@#+` and `@page` tags. */
+export interface IPageNode extends IHeadingNode {
+    /** Ordered list of pages and headings that appear on this page. */
+    children: Array<IPageNode | IHeadingNode>;
+
+    /** Unique reference of this page, used for retrieval from store. */
+    reference: string;
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -5,9 +5,38 @@
  * repository.
  */
 
-/** Slugify a string: "Really Cool Heading!" => "really-cool-heading-" */
-export function slugify(str: string) {
-    return str.toLowerCase().replace(/[^\w.\/]/g, "-");
+export * from "./kss";
+export * from "./markdown";
+export * from "./typescript";
+export * from "./utils";
+
+/**
+ * A single Documentalist page, parsed from a single source file.
+ */
+export interface IPageData extends IBlock {
+    /** Unique identifier for addressing this page. */
+    reference: string;
+
+    /** Fully qualified route to this page: slash-separated references of all parent pages. */
+    route: string;
+
+    /** Human-friendly title of this page. */
+    title: string;
+}
+
+/** An `@#+` tag belongs to a specific page. */
+export interface IHeadingNode extends INavigable {
+    /** Display title of page heading. */
+    title: string;
+}
+
+/** A page has ordered children composed of `@#+` and `@page` tags. */
+export interface IPageNode extends IHeadingNode {
+    /** Ordered list of pages and headings that appear on this page. */
+    children: Array<IPageNode | IHeadingNode>;
+
+    /** Unique reference of this page, used for retrieval from store. */
+    reference: string;
 }
 
 /**
@@ -21,10 +50,6 @@ export interface INavigable {
     /** Level of heading, from 1-6. Dictates which `<h#>` tag to render. */
     level: number;
 }
-
-/*
-@TAGS
-*/
 
 /** Represents a single `@tag <value>` line from a file. */
 export interface ITag {
@@ -49,24 +74,6 @@ export interface IHeadingTag extends ITag, INavigable {
 
 /** An entry in `contents` array: either an HTML string or an `@tag`. */
 export type StringOrTag = string | ITag;
-
-/**
- * Type guard to determine if a `contents` node is an `@tag` statement.
- * Optionally tests tag name too, if `tagName` arg is provided.
- */
-export function isTag(node: any, tagName?: string): node is ITag {
-    return node != null && (node as ITag).tag !== undefined
-        && (tagName === undefined || (node as ITag).tag === tagName);
-}
-
-/** Type guard to deterimine if a `contents` node is an `@#+` heading tag. */
-export function isHeadingTag(node: any): node is IHeadingTag {
-    return isTag(node, "heading");
-}
-
-/*
-PAGE DATA
-*/
 
 /**
  * Metadata is parsed from YAML front matter in files and can contain arbitrary data.
@@ -111,42 +118,4 @@ export interface IBlock {
 
     /** Arbitrary YAML metadata parsed from front matter of source file, if any, or `{}`. */
     metadata: IMetadata;
-}
-
-/**
- * A single Documentalist page, parsed from a single source file.
- */
-export interface IPageData extends IBlock {
-    /** Unique identifier for addressing this page. */
-    reference: string;
-
-    /** Fully qualified route to this page: slash-separated references of all parent pages. */
-    route: string;
-
-    /** Human-friendly title of this page. */
-    title: string;
-}
-
-/*
-LAYOUT HIERARCHY NODES
-*/
-
-/** An `@#+` tag belongs to a specific page. */
-export interface IHeadingNode extends INavigable {
-    /** Display title of page heading. */
-    title: string;
-}
-
-/** A page has ordered children composed of `@#+` and `@page` tags. */
-export interface IPageNode extends IHeadingNode {
-    /** Ordered list of pages and headings that appear on this page. */
-    children: Array<IPageNode | IHeadingNode>;
-
-    /** Unique reference of this page, used for retrieval from store. */
-    reference: string;
-}
-
-/** Type guard for `IPageNode`, useful for its `children` array. */
-export function isPageNode(node: any): node is IPageNode {
-    return node != null && (node as IPageNode).children != null;
 }

--- a/src/client/kss.ts
+++ b/src/client/kss.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain
+ * a copy of the license in the LICENSE and PATENTS files in the root of this
+ * repository.
+ */
+
+/** A single modifier for an example. */
+export interface IKssModifier {
+    documentation: string;
+    name: string;
+}
+
+/**
+ * A markup/modifiers example parsed from a KSS comment block.
+ */
+export interface IKssExample {
+    /** Raw documentation string. */
+    documentation: string;
+    /**
+     * Raw HTML markup for example with `{{.modifier}}` templates,
+     * to be used to render the markup for each modifier.
+     */
+    markup: string;
+    /**
+     * Syntax-highlighted version of the markup HTML, to be used
+     * for rendering the markup itself with pretty colors.
+     */
+    markupHtml: string;
+    /** Array of modifiers supported by HTML markup. */
+    modifiers: IKssModifier[];
+    /** Unique reference for addressing this example. */
+    reference: string;
+}
+
+export interface IKssPluginData {
+    css: {
+        [reference: string]: IKssExample;
+    };
+}

--- a/src/client/markdown.ts
+++ b/src/client/markdown.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain
+ * a copy of the license in the LICENSE and PATENTS files in the root of this
+ * repository.
+ */
+
+import { IPageData, IPageNode } from "./index";
+
+export interface IMarkdownPluginData {
+    /**
+     * An ordered, nested, multi-rooted tree describing the navigation layout
+     * of all the pages and their headings. Uses `@page` and `@#+` tags to build
+     * this representation.
+     */
+    nav: IPageNode[];
+
+    /** A map of page reference to data. */
+    pages: {
+        [reference: string]: IPageData;
+    };
+}

--- a/src/client/typescript.ts
+++ b/src/client/typescript.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain
+ * a copy of the license in the LICENSE and PATENTS files in the root of this
+ * repository.
+ */
+
+import { IJsDocTags } from "ts-quick-docs";
+import { IBlock } from "./index";
+
+export interface ITsDocEntry {
+    documentation: IBlock;
+    fileName: string;
+    name: string;
+    tags: IJsDocTags;
+    type: string;
+}
+
+export interface ITsPropertyEntry extends ITsDocEntry {
+    optional?: boolean;
+}
+
+export interface ITsInterfaceEntry extends ITsDocEntry {
+    extends?: string[];
+    properties: ITsPropertyEntry[];
+}
+
+export interface ITypescriptPluginData {
+    ts: {
+        [name: string]: ITsInterfaceEntry;
+    };
+}

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain
+ * a copy of the license in the LICENSE and PATENTS files in the root of this
+ * repository.
+ */
+
+import { IHeadingTag, IPageNode, ITag } from "./index";
+
+/** Slugify a string: "Really Cool Heading!" => "really-cool-heading-" */
+export function slugify(str: string) {
+    return str.toLowerCase().replace(/[^\w.\/]/g, "-");
+}
+
+/**
+ * Type guard to determine if a `contents` node is an `@tag` statement.
+ * Optionally tests tag name too, if `tagName` arg is provided.
+ */
+export function isTag(node: any, tagName?: string): node is ITag {
+    return node != null && (node as ITag).tag !== undefined
+        && (tagName === undefined || (node as ITag).tag === tagName);
+}
+
+/** Type guard to deterimine if a `contents` node is an `@#+` heading tag. */
+export function isHeadingTag(node: any): node is IHeadingTag {
+    return isTag(node, "heading");
+}
+
+/** Type guard for `IPageNode`, useful for its `children` array. */
+export function isPageNode(node: any): node is IPageNode {
+    return node != null && (node as IPageNode).children != null;
+}

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1,7 +1,7 @@
 import * as yaml from "js-yaml";
 import * as marked from "marked";
-import { IHeadingTag } from "./client";
-import { IBlock, ICompiler, StringOrTag } from "./plugins/plugin";
+import { IBlock, IHeadingTag, StringOrTag} from "./client";
+import { ICompiler } from "./plugins";
 
 /**
  * Matches the triple-dash metadata block on the first line of markdown file.

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -7,5 +7,5 @@
 
 export * from "./kss";
 export * from "./markdown";
-export * from "./plugin";
 export * from "./typescript";
+export * from "./plugin";

--- a/src/plugins/kss.ts
+++ b/src/plugins/kss.ts
@@ -7,41 +7,8 @@
 
 import * as kss from "kss";
 import * as path from "path";
+import { IKssExample, IKssModifier, IKssPluginData } from "../client";
 import { ICompiler, IFile, IPlugin } from "./plugin";
-
-/** A single modifier for an example. */
-export interface IKssModifier {
-    documentation: string;
-    name: string;
-}
-
-/**
- * A markup/modifiers example parsed from a KSS comment block.
- */
-export interface IKssExample {
-    /** Raw documentation string. */
-    documentation: string;
-    /**
-     * Raw HTML markup for example with `{{.modifier}}` templates,
-     * to be used to render the markup for each modifier.
-     */
-    markup: string;
-    /**
-     * Syntax-highlighted version of the markup HTML, to be used
-     * for rendering the markup itself with pretty colors.
-     */
-    markupHtml: string;
-    /** Array of modifiers supported by HTML markup. */
-    modifiers: IKssModifier[];
-    /** Unique reference for addressing this example. */
-    reference: string;
-}
-
-export interface IKssPluginData {
-    css: {
-        [reference: string]: IKssExample;
-    };
-}
 
 export class KssPlugin implements IPlugin<IKssPluginData> {
     public constructor(private options: kss.IOptions) {

--- a/src/plugins/markdown.ts
+++ b/src/plugins/markdown.ts
@@ -6,23 +6,18 @@
  */
 
 import * as path from "path";
-import { IBlock, IHeadingNode, IPageData, IPageNode, isHeadingTag, isPageNode, slugify } from "../client";
+import {
+    IBlock,
+    IHeadingNode,
+    IMarkdownPluginData,
+    IPageData,
+    IPageNode,
+    isHeadingTag,
+    isPageNode,
+    slugify,
+} from "../client";
 import { PageMap } from "../page";
 import { ICompiler, IFile, IPlugin } from "./plugin";
-
-export interface IMarkdownPluginData {
-    /**
-     * An ordered, nested, multi-rooted tree describing the navigation layout
-     * of all the pages and their headings. Uses `@page` and `@#+` tags to build
-     * this representation.
-     */
-    nav: IPageNode[];
-
-    /** A map of page reference to data. */
-    pages: {
-        [reference: string]: IPageData;
-    };
-}
 
 export interface IMarkdownPluginOptions {
     /**

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -5,9 +5,7 @@
  * repository.
  */
 
-import { IBlock, StringOrTag } from "../client";
-
-export { IBlock, StringOrTag };
+import { IBlock } from "../client";
 
 /**
  * Abstract representation of a file, containing absolute path and synchronous `read` operation.

--- a/src/plugins/typescript.ts
+++ b/src/plugins/typescript.ts
@@ -5,31 +5,9 @@
  * repository.
  */
 
-import tsdoc, { IDocumentationOptions, IJsDocTags } from "ts-quick-docs";
-import { IBlock, ICompiler, IFile, IPlugin } from "./plugin";
-
-export interface ITsDocEntry {
-    documentation: IBlock;
-    fileName: string;
-    name: string;
-    tags: IJsDocTags;
-    type: string;
-}
-
-export interface ITsPropertyEntry extends ITsDocEntry {
-    optional?: boolean;
-}
-
-export interface ITsInterfaceEntry extends ITsDocEntry {
-    extends?: string[];
-    properties: ITsPropertyEntry[];
-}
-
-export interface ITypescriptPluginData {
-    ts: {
-        [name: string]: ITsInterfaceEntry;
-    };
-}
+import tsdoc, { IDocumentationOptions } from "ts-quick-docs";
+import { ITsInterfaceEntry, ITsPropertyEntry, ITypescriptPluginData } from "../client";
+import { ICompiler, IFile, IPlugin } from "./plugin";
 
 export class TypescriptPlugin implements IPlugin<ITypescriptPluginData> {
     public constructor(


### PR DESCRIPTION
This refactor will allow typescript projects to `import ... from "documentalist/dist/client";` to receive typings for documentalist output that will work in a browser environment without bringing in server-side typings.