### PR TITLE
bugfix: Windows newline compile errors

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7,13 +7,13 @@ import { ICompiler } from "./plugins";
  * Matches the triple-dash metadata block on the first line of markdown file.
  * The first capture group contains YAML content.
  */
-const METADATA_REGEX = /^---\n?((?:.|\n)*)\n---\n/;
+const METADATA_REGEX = /^---\r?\n?((?:.|\r?\n)*)\r?\n---\r?\n/;
 
 /**
  * Splits text content for lines that begin with `@tagName`.
  */
-const TAG_REGEX = /^@(\S+)(?:\s+([^\n]+))?$/;
-const TAG_SPLIT_REGEX = /^(@\S+(?:\s+[^\n]+)?)$/gm;
+const TAG_REGEX = /^@(\S+)(?:\s+([^\r?\n]+))?$/;
+const TAG_SPLIT_REGEX = /^(@\S+(?:\s+[^\r?\n]+)?)$/gm;
 
 export interface ICompilerOptions {
     /** Options for markdown rendering. See https://github.com/chjj/marked#options-1. */


### PR DESCRIPTION
Small change to allow files with \r\n endings match.

Allows palantir/blueprint#286 to be fixed.