### PR TITLE
more options!

### DIFF
--- a/src/__tests__/__fixtures__/classes.ts
+++ b/src/__tests__/__fixtures__/classes.ts
@@ -18,11 +18,11 @@ export class Animal {
      * @param food Name of the food to eat.
      */
     public eat(food: string) {
-        this.consume(Food.retrieve(food), true);
+        this.consumePrivate(Food.retrieve(food), true);
     }
 
     /** Private method does not appear in output. */
-    private consume(food: Food, allOfIt = false) {
+    private consumePrivate(food: Food, allOfIt = false) {
         if (allOfIt) {
             food.destroy();
         }

--- a/src/__tests__/__snapshots__/typescript.test.ts.snap
+++ b/src/__tests__/__snapshots__/typescript.test.ts.snap
@@ -723,3 +723,32 @@ is.",
   },
 }
 `;
+
+exports[`TypescriptPlugin options excludeNames 1`] = `
+Array [
+  "active",
+  "disabled",
+  "elementRef",
+  "loading",
+  "onClick",
+  "text",
+  "type",
+]
+`;
+
+exports[`TypescriptPlugin options excludePaths 1`] = `Object {}`;
+
+exports[`TypescriptPlugin options includeNonExportedMembers 1`] = `
+Array [
+  "Animal",
+  "Food",
+]
+`;
+
+exports[`TypescriptPlugin options includePrivateMembers 1`] = `
+Array [
+  "bark",
+  "consumePrivate",
+  "eat",
+]
+`;

--- a/src/__tests__/typescript.test.ts
+++ b/src/__tests__/typescript.test.ts
@@ -6,18 +6,45 @@
  */
 
 import { Documentalist } from "../documentalist";
-import { TypescriptPlugin } from "../plugins/typescript/index";
+import { ITypescriptPluginData } from "../plugins/index";
+import { ITypescriptPluginOptions, TypescriptPlugin } from "../plugins/typescript/index";
 
 describe("TypescriptPlugin", () => {
-    const dm = Documentalist.create().use(".ts", new TypescriptPlugin());
+    it("classes snapshot", () => expectSnapshot("classes"));
+    it("interfaces snapshot", () => expectSnapshot("interfaces"));
 
-    snapshot("classes");
-    snapshot("interfaces");
-
-    function snapshot(name: string) {
-        it(`${name} snapshot`, async () => {
-            const { typescript } = await dm.documentGlobs(`src/__tests__/__fixtures__/${name}.ts`);
-            expect(typescript).toMatchSnapshot();
+    describe("options", () => {
+        it("excludePaths", () => {
+            // this snapshot is empty: everything is excluded.
+            // `src` entry is to test brace glob construction.
+            expectSnapshot("classes", { excludePaths: ["**/__fixtures__/**", "src"] });
         });
-    }
+
+        it("excludeNames", () => {
+            // get IButtonProps properties; should be missing a few.
+            expectSnapshot("interfaces", { excludeNames: [/icon/i, "intent"] }, data =>
+                data.IButtonProps.properties.map(p => p.name),
+            );
+        });
+
+        it("includePrivateMembers", () => {
+            // class Animal has a private method
+            expectSnapshot("classes", { includePrivateMembers: true }, data => data.Animal.methods.map(m => m.name));
+        });
+
+        it("includeNonExportedMembers", () => {
+            // expect to see Animal (exported) and Food (not exported) here
+            expectSnapshot("classes", { includeNonExportedMembers: true }, Object.keys);
+        });
+    });
 });
+
+async function expectSnapshot(
+    name: string,
+    options?: ITypescriptPluginOptions,
+    transform: (data: ITypescriptPluginData["typescript"]) => any = arg => arg,
+) {
+    const dm = Documentalist.create().use(".ts", new TypescriptPlugin(options));
+    const { typescript } = await dm.documentGlobs(`src/__tests__/__fixtures__/${name}.ts`);
+    expect(transform(typescript)).toMatchSnapshot();
+}

--- a/src/__tests__/typescript.test.ts
+++ b/src/__tests__/typescript.test.ts
@@ -40,8 +40,10 @@ describe("TypescriptPlugin", () => {
 });
 
 async function expectSnapshot(
+    /** name of fixture file to feed into DM */
     name: string,
     options?: ITypescriptPluginOptions,
+    /** a function to transform the DM data, to avoid snapshotting _everything_. defaults to identity function. */
     transform: (data: ITypescriptPluginData["typescript"]) => any = arg => arg,
 ) {
     const dm = Documentalist.create().use(".ts", new TypescriptPlugin(options));

--- a/src/plugins/typescript/visitor.ts
+++ b/src/plugins/typescript/visitor.ts
@@ -118,8 +118,13 @@ export class Visitor {
         return this.compiler.renderBlock(documentation);
     }
 
-    private filterReflection = (def: Reflection) =>
-        def.flags.isExported === true || this.options.includeNonExported === true;
+    private filterReflection = (def: Reflection) => {
+        const { excludeNames = [], includeNonExportedMembers = false } = this.options;
+        return (
+            (def.flags.isExported === true || includeNonExportedMembers) &&
+            excludeNames.every(pattern => def.name.match(pattern) == null)
+        );
+    };
 }
 
 function getCommentTag(comment: Comment, tagName: string) {


### PR DESCRIPTION
`excludePaths` & `excludeNames` & `includeDeclarations`, like the original ts-quick-docs solution