### PR TITLE
excludePaths works like excludeNames

### DIFF
--- a/src/plugins/typescript/index.ts
+++ b/src/plugins/typescript/index.ts
@@ -13,13 +13,19 @@ export { ITypescriptPluginData };
 
 export interface ITypescriptPluginOptions {
     /**
-     * Array of glob strings to exclude entire files. Files in `node_modules/` are always excluded.
-     * Note that when matching directories you'll need to capture the entire path using `**`s on either end.
+     * Array of patterns (string or RegExp) to exclude members by name.
+     * Strings will be converted to regular expressions through `string.match(pattern)`.
+     *
+     * Note that excluded members will still be parsed by the compiler, so they can be referenced
+     * by other symbols, but they will not appear in the output data.
      */
-    excludePaths?: string[];
-
-    /** Array of patterns (string or RegExp) to exclude named members. */
     excludeNames?: Array<string | RegExp>;
+
+    /**
+     * Array of patterns (string or RegExp) to exclude members based on file path.
+     * See `excludeNames` above for usage notes.
+     */
+    excludePaths?: Array<string | RegExp>;
 
     /**
      * Enable parsing of `.d.ts` files.

--- a/src/plugins/typescript/visitor.ts
+++ b/src/plugins/typescript/visitor.ts
@@ -131,15 +131,16 @@ export class Visitor {
     });
 
     /** Visits each child that passes the filter condition (based on options). */
-    private visitChildren<T>(
+    private visitChildren<T extends ITsDocBase>(
         children: Reflection[],
         visitor: (def: DeclarationReflection) => T,
         comparator?: (a: T, b: T) => number,
     ): T[] {
-        const { excludeNames = [], includeNonExportedMembers = false } = this.options;
+        const { excludeNames = [], excludePaths = [], includeNonExportedMembers = false } = this.options;
         return children
-            .filter(ref => (ref.flags.isExported || includeNonExportedMembers) && isNotExcluded(excludeNames, ref.name))
+            .filter(ref => ref.flags.isExported || includeNonExportedMembers)
             .map(visitor)
+            .filter(doc => isNotExcluded(excludeNames, doc.name) && isNotExcluded(excludePaths, doc.fileName))
             .sort(comparator);
     }
 


### PR DESCRIPTION
- :fire: `excludePaths` is not passed to typedoc but rather used at the same time as `excludeNames` when visiting children
  - this means string patterns are interpreted as regexes, not globs.
  - accepts `string | RegExp` patterns