### PR TITLE
upgrade typedoc, use ts 2.7

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,7 +11,7 @@
       <h3>Interfaces</h3><a class="nav-item" href="#IBlock"><code>IBlock</code></a><a class="nav-item" href="#ICompiler"><code>ICompiler</code></a><a class="nav-item" href="#ICompilerOptions"><code>ICompilerOptions</code></a><a class="nav-item" href="#IFile"><code>IFile</code></a><a class="nav-item" href="#IHeadingNode"><code>IHeadingNode</code></a><a class="nav-item" href="#IHeadingTag"><code>IHeadingTag</code></a><a class="nav-item" href="#IKssExample"><code>IKssExample</code></a><a class="nav-item" href="#IKssModifier"><code>IKssModifier</code></a><a class="nav-item" href="#IKssPluginData"><code>IKssPluginData</code></a><a class="nav-item" href="#IMarkdownPluginData"><code>IMarkdownPluginData</code></a><a class="nav-item" href="#IMarkdownPluginOptions"><code>IMarkdownPluginOptions</code></a><a class="nav-item" href="#IMetadata"><code>IMetadata</code></a><a class="nav-item" href="#INavigable"><code>INavigable</code></a><a class="nav-item" href="#IPageData"><code>IPageData</code></a><a class="nav-item" href="#IPageNode"><code>IPageNode</code></a><a class="nav-item" href="#IPlugin"><code>IPlugin</code></a><a class="nav-item" href="#IPluginEntry"><code>IPluginEntry</code></a><a class="nav-item" href="#ITag"><code>ITag</code></a><a class="nav-item" href="#ITsCallable"><code>ITsCallable</code></a><a class="nav-item" href="#ITsClass"><code>ITsClass</code></a><a class="nav-item" href="#ITsConstructor"><code>ITsConstructor</code></a><a class="nav-item" href="#ITsDefaultValue"><code>ITsDefaultValue</code></a><a class="nav-item" href="#ITsDocBase"><code>ITsDocBase</code></a><a class="nav-item" href="#ITsEnum"><code>ITsEnum</code></a><a class="nav-item" href="#ITsEnumMember"><code>ITsEnumMember</code></a><a class="nav-item" href="#ITsFlags"><code>ITsFlags</code></a><a class="nav-item" href="#ITsInterface"><code>ITsInterface</code></a><a class="nav-item" href="#ITsMethod"><code>ITsMethod</code></a><a class="nav-item" href="#ITsObjectDefinition"><code>ITsObjectDefinition</code></a><a class="nav-item" href="#ITsParameter"><code>ITsParameter</code></a><a class="nav-item" href="#ITsProperty"><code>ITsProperty</code></a><a class="nav-item" href="#ITsSignature"><code>ITsSignature</code></a><a class="nav-item" href="#ITsTypeAlias"><code>ITsTypeAlias</code></a><a class="nav-item" href="#ITypescriptPluginData"><code>ITypescriptPluginData</code></a><a class="nav-item" href="#ITypescriptPluginOptions"><code>ITypescriptPluginOptions</code></a>
       <h3>Enums</h3><a class="nav-item" href="#Kind"><code>Kind</code></a>
       <h3>Aliases</h3><a class="nav-item" href="#StringOrTag"><code>StringOrTag</code></a>
-      <h4>v1.0.0-beta.3
+      <h4>v1.0.0
 
       </h4>
       <div class="copyright">&copy; Copyright 2017-present Palantir</div>
@@ -46,20 +46,20 @@ and <code>await</code> your magical blob of documentation data!</p>
 </ul>
 <h3 id="node">Node</h3>
 <p>Register plugins with <code>.use(pattern, plugin)</code>. Supply a <code>pattern</code> to match files against; matched files will be compiled by the <code>plugin</code>. Documentation data will be collected into a single blob and can be easily written to a file or fed into another tool.</p>
-<pre><code class="lang-js"><span class="hljs-keyword">const</span> { Documentalist, MarkdownPlugin, TypescriptPlugin } = <span class="hljs-built_in">require</span>(<span class="hljs-string">"documentalist"</span>);
-<span class="hljs-keyword">const</span> { writeFileSync } = <span class="hljs-built_in">require</span>(<span class="hljs-string">"fs"</span>);
+<pre><code class="lang-js">const { Documentalist, MarkdownPlugin, TypescriptPlugin } = require(&quot;documentalist&quot;);
+const { writeFileSync } = require(&quot;fs&quot;);
 
-<span class="hljs-keyword">new</span> Documentalist()
-  .use(<span class="hljs-string">".md"</span>, <span class="hljs-keyword">new</span> MarkdownPlugin())
-  .use(<span class="hljs-regexp">/\.tsx?$/</span>, <span class="hljs-keyword">new</span> TypescriptPlugin({ <span class="hljs-attr">excludeNames</span>: [<span class="hljs-regexp">/I.+State$/</span>] }))
-  .documentGlobs(<span class="hljs-string">"src/**/*"</span>) <span class="hljs-comment">// ← async operation, returns a Promise</span>
-  .then(<span class="hljs-function"><span class="hljs-params">docs</span> =&gt;</span> <span class="hljs-built_in">JSON</span>.stringify(docs, <span class="hljs-literal">null</span>, <span class="hljs-number">2</span>))
-  .then(<span class="hljs-function"><span class="hljs-params">json</span> =&gt;</span> writeFileSync(<span class="hljs-string">"docs.json"</span>, json))
+new Documentalist()
+  .use(&quot;.md&quot;, new MarkdownPlugin())
+  .use(/\.tsx?$/, new TypescriptPlugin({ excludeNames: [/I.+State$/] }))
+  .documentGlobs(&quot;src/**/*&quot;) // ← async operation, returns a Promise
+  .then(docs =&gt; JSON.stringify(docs, null, 2))
+  .then(json =&gt; writeFileSync(&quot;docs.json&quot;, json))
 </code></pre>
 
       <blockquote>
         <div class="interface-block" id="Documentalist">
-          <h2 class="interface-title"><code><small>class</small> Documentalist<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/documentalist.ts#L22" target="_blank" title="View source">#</a></small></code></h2>
+          <h2 class="interface-title"><code><small>class</small> Documentalist<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/documentalist.ts#L22" target="_blank" title="View source">#</a></small></code></h2>
           <h3>Constructor</h3>
           <div class="interface-properties">
             <table>
@@ -141,7 +141,7 @@ The CSS plugin can be enabled with <code>--css</code>. Plugins can be disabled w
 <blockquote>
 <p><strong>Options are not supported</strong> via the command line interface :sob:.</p>
 </blockquote>
-<pre><code class="lang-sh">documentalist <span class="hljs-string">"src/**/*"</span> --css --no-ts &gt; docs.json
+<pre><code class="lang-sh">documentalist &quot;src/**/*&quot; --css --no-ts &gt; docs.json
 </code></pre>
 <h3 id="plugins">Plugins</h3>
 <p>Documentalist uses a plugin architecture to support arbitrary file types.
@@ -152,25 +152,25 @@ instance that can be used to render blocks of markdown text.</p>
 
       <blockquote>
         <div class="interface-block" id="IPlugin">
-          <h2 class="interface-title"><code><small>interface</small> IPlugin<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/plugin.ts#L37" target="_blank" title="View source">#</a></small></code></h2><p>A Documentalist plugin is an object with a <code>compile(files, compiler)</code> function
+          <h2 class="interface-title"><code><small>interface</small> IPlugin<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/plugin.ts#L37" target="_blank" title="View source">#</a></small></code></h2><p>A Documentalist plugin is an object with a <code>compile(files, compiler)</code> function
 that returns a data object (or a promise for that object).</p>
 <p>A common pattern is to define a class that implements this interface and use the constructor
 to accept options.</p>
-<pre><code class="lang-ts"><span class="hljs-keyword">import</span> { ICompiler, IFile, IPlugin } <span class="hljs-keyword">from</span> <span class="hljs-string">"documentalist/client"</span>;
+<pre><code class="lang-ts">import { ICompiler, IFile, IPlugin } from &quot;documentalist/client&quot;;
 
-<span class="hljs-keyword">export</span> <span class="hljs-keyword">interface</span> MyData {
+export interface MyData {
     pluginName: { ... }
 }
 
-<span class="hljs-keyword">export</span> <span class="hljs-keyword">interface</span> MyOptions {
+export interface MyOptions {
     ...
 }
 
-<span class="hljs-keyword">export</span> <span class="hljs-keyword">class</span> MyPlugin <span class="hljs-keyword">implements</span> IPlugin&lt;MyData&gt; {
-    <span class="hljs-keyword">public</span> <span class="hljs-keyword">constructor</span>(<span class="hljs-params">options: MyOptions = {}</span>) {}
+export class MyPlugin implements IPlugin&lt;MyData&gt; {
+    public constructor(options: MyOptions = {}) {}
 
-    <span class="hljs-keyword">public</span> compile(files: IFile[], compiler: ICompiler) {
-        <span class="hljs-keyword">return</span> files.map(transformToMyData);
+    public compile(files: IFile[], compiler: ICompiler) {
+        return files.map(transformToMyData);
     }
 }
 </code></pre>
@@ -203,7 +203,7 @@ and includes a <a href="https://github.com/palantir/documentalist/blob/master/PA
     </article>
     <section data-route="Compiler" hidden="hidden">
       <div class="interface-block" id="Compiler">
-        <h2 class="interface-title"><code><small>class</small> Compiler<small> implements <a href="#ICompiler">ICompiler</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/compiler.ts#L36" target="_blank" title="View source">#</a></small></code></h2>
+        <h2 class="interface-title"><code><small>class</small> Compiler<small> implements <a href="#ICompiler">ICompiler</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/compiler.ts#L36" target="_blank" title="View source">#</a></small></code></h2>
         <h3>Constructor</h3>
         <div class="interface-properties">
           <table>
@@ -250,7 +250,7 @@ and includes a <a href="https://github.com/palantir/documentalist/blob/master/PA
     </section>
     <section data-route="Documentalist" hidden="hidden">
       <div class="interface-block" id="Documentalist">
-        <h2 class="interface-title"><code><small>class</small> Documentalist<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/documentalist.ts#L22" target="_blank" title="View source">#</a></small></code></h2>
+        <h2 class="interface-title"><code><small>class</small> Documentalist<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/documentalist.ts#L22" target="_blank" title="View source">#</a></small></code></h2>
         <h3>Constructor</h3>
         <div class="interface-properties">
           <table>
@@ -329,7 +329,7 @@ supplied pattern.</p>
     </section>
     <section data-route="PageMap" hidden="hidden">
       <div class="interface-block" id="PageMap">
-        <h2 class="interface-title"><code><small>class</small> PageMap<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/page.ts#L10" target="_blank" title="View source">#</a></small></code></h2>
+        <h2 class="interface-title"><code><small>class</small> PageMap<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/page.ts#L10" target="_blank" title="View source">#</a></small></code></h2>
         <h3>Methods</h3>
         <div class="interface-properties">
           <table>
@@ -393,7 +393,7 @@ Warns if a page with this ID already exists.</p>
     </section>
     <section data-route="MarkdownPlugin" hidden="hidden">
       <div class="interface-block" id="MarkdownPlugin">
-        <h2 class="interface-title"><code><small>class</small> MarkdownPlugin<small> implements <a href="#IPlugin">IPlugin</a>&lt;<a href="#IMarkdownPluginData">IMarkdownPluginData</a>&gt;</small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/plugins/markdown.ts#L40" target="_blank" title="View source">#</a></small></code></h2><p>The <code>MarkdownPlugin</code> parses and renders markdown pages and produces a navigation tree of all documents.
+        <h2 class="interface-title"><code><small>class</small> MarkdownPlugin<small> implements <a href="#IPlugin">IPlugin</a>&lt;<a href="#IMarkdownPluginData">IMarkdownPluginData</a>&gt;</small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/plugins/markdown.ts#L40" target="_blank" title="View source">#</a></small></code></h2><p>The <code>MarkdownPlugin</code> parses and renders markdown pages and produces a navigation tree of all documents.
 This plugin traces <code>@page</code> and <code>@#+</code> &quot;heading&quot; tags to discover pages (given a single starting <code>navPage</code>)
 and build up a tree representation of those pages.</p>
 
@@ -435,7 +435,7 @@ Returns a plain object mapping page references to their data.</p>
     </section>
     <section data-route="Visitor" hidden="hidden">
       <div class="interface-block" id="Visitor">
-        <h2 class="interface-title"><code><small>class</small> Visitor<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/plugins/typescript/visitor.ts#L38" target="_blank" title="View source">#</a></small></code></h2>
+        <h2 class="interface-title"><code><small>class</small> Visitor<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/plugins/typescript/visitor.ts#L38" target="_blank" title="View source">#</a></small></code></h2>
         <h3>Constructor</h3>
         <div class="interface-properties">
           <table>
@@ -466,7 +466,7 @@ Returns a plain object mapping page references to their data.</p>
     </section>
     <section data-route="TypescriptPlugin" hidden="hidden">
       <div class="interface-block" id="TypescriptPlugin">
-        <h2 class="interface-title"><code><small>class</small> TypescriptPlugin<small> implements <a href="#IPlugin">IPlugin</a>&lt;<a href="#ITypescriptPluginData">ITypescriptPluginData</a>&gt;</small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/plugins/typescript/index.ts#L68" target="_blank" title="View source">#</a></small></code></h2>
+        <h2 class="interface-title"><code><small>class</small> TypescriptPlugin<small> implements <a href="#IPlugin">IPlugin</a>&lt;<a href="#ITypescriptPluginData">ITypescriptPluginData</a>&gt;</small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/plugins/typescript/index.ts#L68" target="_blank" title="View source">#</a></small></code></h2>
         <h3>Constructor</h3>
         <div class="interface-properties">
           <table>
@@ -497,7 +497,7 @@ Returns a plain object mapping page references to their data.</p>
     </section>
     <section data-route="KssPlugin" hidden="hidden">
       <div class="interface-block" id="KssPlugin">
-        <h2 class="interface-title"><code><small>class</small> KssPlugin<small> implements <a href="#IPlugin">IPlugin</a>&lt;<a href="#IKssPluginData">IKssPluginData</a>&gt;</small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/plugins/kss.ts#L19" target="_blank" title="View source">#</a></small></code></h2><p>The <code>KSSPlugin</code> extracts <a href="http://warpspire.com/kss/syntax/">KSS doc comments</a> from CSS code (or similar languages).
+        <h2 class="interface-title"><code><small>class</small> KssPlugin<small> implements <a href="#IPlugin">IPlugin</a>&lt;<a href="#IKssPluginData">IKssPluginData</a>&gt;</small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/plugins/kss.ts#L19" target="_blank" title="View source">#</a></small></code></h2><p>The <code>KSSPlugin</code> extracts <a href="http://warpspire.com/kss/syntax/">KSS doc comments</a> from CSS code (or similar languages).
 It emits an object keyed by the &quot;styleguide [ref]&quot; section of the comment. The documentation, markup, and modifiers
 sections will all be emitted in the data.</p>
 
@@ -534,7 +534,7 @@ sections will all be emitted in the data.</p>
     </section>
     <section data-route="ITsCallable" hidden="hidden">
       <div class="interface-block" id="ITsCallable">
-        <h2 class="interface-title"><code><small>interface</small> ITsCallable<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L68" target="_blank" title="View source">#</a></small></code></h2><p>Common type for a callable member, something that can be invoked.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsCallable<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L68" target="_blank" title="View source">#</a></small></code></h2><p>Common type for a callable member, something that can be invoked.</p>
 
         <blockquote>
           <p>see: <code><a href="#ITsConstructor">ITsConstructor</a></code></p>
@@ -569,7 +569,7 @@ sections will all be emitted in the data.</p>
     </section>
     <section data-route="ITag" hidden="hidden">
       <div class="interface-block" id="ITag">
-        <h2 class="interface-title"><code><small>interface</small> ITag<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/tags.ts#L9" target="_blank" title="View source">#</a></small></code></h2><p>Represents a single <code>@tag &lt;value&gt;</code> line from a file.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITag<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/tags.ts#L9" target="_blank" title="View source">#</a></small></code></h2><p>Represents a single <code>@tag &lt;value&gt;</code> line from a file.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -598,7 +598,7 @@ sections will all be emitted in the data.</p>
     </section>
     <section data-route="IHeadingTag" hidden="hidden">
       <div class="interface-block" id="IHeadingTag">
-        <h2 class="interface-title"><code><small>interface</small> IHeadingTag<small> extends <a href="#ITag">ITag</a>, <a href="#INavigable">INavigable</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/tags.ts#L37" target="_blank" title="View source">#</a></small></code></h2><p>Represents a single <code>@#+ &lt;value&gt;</code> heading tag from a file. Note that all <code>@#+</code> tags
+        <h2 class="interface-title"><code><small>interface</small> IHeadingTag<small> extends <a href="#ITag">ITag</a>, <a href="#INavigable">INavigable</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/tags.ts#L37" target="_blank" title="View source">#</a></small></code></h2><p>Represents a single <code>@#+ &lt;value&gt;</code> heading tag from a file. Note that all <code>@#+</code> tags
 (<code>@#</code> through <code>@######</code>) are emitted as <code>tag: &quot;heading&quot;</code> so only one renderer is necessary to
 capture all six levels.</p>
 <p>Heading tags include additional information over regular tags: fully-qualified <code>route</code> of the
@@ -648,7 +648,7 @@ heading (which can be used as anchor <code>href</code>), and <code>level</code> 
     </section>
     <section data-route="ICompiler" hidden="hidden">
       <div class="interface-block" id="ICompiler">
-        <h2 class="interface-title"><code><small>interface</small> ICompiler<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/compiler.ts#L13" target="_blank" title="View source">#</a></small></code></h2><p>Each plugin receives a <code>Compiler</code> instance to aid in the processing of source files.</p>
+        <h2 class="interface-title"><code><small>interface</small> ICompiler<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/compiler.ts#L13" target="_blank" title="View source">#</a></small></code></h2><p>Each plugin receives a <code>Compiler</code> instance to aid in the processing of source files.</p>
 
         <h3>Methods</h3>
         <div class="interface-properties">
@@ -692,13 +692,13 @@ is.</p>
     </section>
     <section data-route="IMetadata" hidden="hidden">
       <div class="interface-block" id="IMetadata">
-        <h2 class="interface-title"><code><small>interface</small> IMetadata<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/compiler.ts#L50" target="_blank" title="View source">#</a></small></code></h2><p>Metadata is parsed from YAML front matter in files and can contain arbitrary data.
+        <h2 class="interface-title"><code><small>interface</small> IMetadata<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/compiler.ts#L50" target="_blank" title="View source">#</a></small></code></h2><p>Metadata is parsed from YAML front matter in files and can contain arbitrary data.
 A few keys are understood by Documentalist and, if defined in front matter,
 will override default behavior.</p>
 <pre><code class="lang-md">---
 reference: overview
-<span class="hljs-section">title: "Welcome to the Jungle"
----</span>
+title: &quot;Welcome to the Jungle&quot;
+---
 actual contents of file...
 </code></pre>
 
@@ -729,7 +729,7 @@ actual contents of file...
     </section>
     <section data-route="IBlock" hidden="hidden">
       <div class="interface-block" id="IBlock">
-        <h2 class="interface-title"><code><small>interface</small> IBlock<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/compiler.ts#L71" target="_blank" title="View source">#</a></small></code></h2><p>The output of <code>renderBlock</code> which parses a long form documentation block into
+        <h2 class="interface-title"><code><small>interface</small> IBlock<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/compiler.ts#L71" target="_blank" title="View source">#</a></small></code></h2><p>The output of <code>renderBlock</code> which parses a long form documentation block into
 metadata, rendered markdown, and tags.</p>
 
         <h3>Properties</h3>
@@ -768,7 +768,7 @@ metadata, rendered markdown, and tags.</p>
     </section>
     <section data-route="IKssModifier" hidden="hidden">
       <div class="interface-block" id="IKssModifier">
-        <h2 class="interface-title"><code><small>interface</small> IKssModifier<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/kss.ts#L9" target="_blank" title="View source">#</a></small></code></h2><p>A single modifier for an example.</p>
+        <h2 class="interface-title"><code><small>interface</small> IKssModifier<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/kss.ts#L9" target="_blank" title="View source">#</a></small></code></h2><p>A single modifier for an example.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -795,7 +795,7 @@ metadata, rendered markdown, and tags.</p>
     </section>
     <section data-route="IKssExample" hidden="hidden">
       <div class="interface-block" id="IKssExample">
-        <h2 class="interface-title"><code><small>interface</small> IKssExample<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/kss.ts#L17" target="_blank" title="View source">#</a></small></code></h2><p>A markup/modifiers example parsed from a KSS comment block.</p>
+        <h2 class="interface-title"><code><small>interface</small> IKssExample<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/kss.ts#L17" target="_blank" title="View source">#</a></small></code></h2><p>A markup/modifiers example parsed from a KSS comment block.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -853,7 +853,7 @@ for rendering the markup itself with pretty colors.</p>
     </section>
     <section data-route="IKssPluginData" hidden="hidden">
       <div class="interface-block" id="IKssPluginData">
-        <h2 class="interface-title"><code><small>interface</small> IKssPluginData<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/kss.ts#L41" target="_blank" title="View source">#</a></small></code></h2><p>The <code>KssPlugin</code> exports a <code>css</code> key that contains a map of styleguide references to markup/modifier examples.</p>
+        <h2 class="interface-title"><code><small>interface</small> IKssPluginData<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/kss.ts#L41" target="_blank" title="View source">#</a></small></code></h2><p>The <code>KssPlugin</code> exports a <code>css</code> key that contains a map of styleguide references to markup/modifier examples.</p>
 
         <blockquote>
           <p>see: <code>KSSPlugin</code></p>
@@ -875,7 +875,7 @@ for rendering the markup itself with pretty colors.</p>
     </section>
     <section data-route="IMarkdownPluginData" hidden="hidden">
       <div class="interface-block" id="IMarkdownPluginData">
-        <h2 class="interface-title"><code><small>interface</small> IMarkdownPluginData<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/markdown.ts#L15" target="_blank" title="View source">#</a></small></code></h2><p>The <code>MarkdownPlugin</code> exports a map of markdown <code>pages</code> keyed by reference,
+        <h2 class="interface-title"><code><small>interface</small> IMarkdownPluginData<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/markdown.ts#L15" target="_blank" title="View source">#</a></small></code></h2><p>The <code>MarkdownPlugin</code> exports a map of markdown <code>pages</code> keyed by reference,
 and a multi-rooted <code>nav</code> tree of page nodes.</p>
 
         <h3>Properties</h3>
@@ -907,7 +907,7 @@ tracing <code>@page</code> and <code>@#+</code> tags.</p>
     </section>
     <section data-route="IPageData" hidden="hidden">
       <div class="interface-block" id="IPageData">
-        <h2 class="interface-title"><code><small>interface</small> IPageData<small> extends <a href="#IBlock">IBlock</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/markdown.ts#L32" target="_blank" title="View source">#</a></small></code></h2><p>A single Documentalist page, parsed from a single source file.</p>
+        <h2 class="interface-title"><code><small>interface</small> IPageData<small> extends <a href="#IBlock">IBlock</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/markdown.ts#L32" target="_blank" title="View source">#</a></small></code></h2><p>A single Documentalist page, parsed from a single source file.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -972,7 +972,7 @@ tracing <code>@page</code> and <code>@#+</code> tags.</p>
     </section>
     <section data-route="IHeadingNode" hidden="hidden">
       <div class="interface-block" id="IHeadingNode">
-        <h2 class="interface-title"><code><small>interface</small> IHeadingNode<small> extends <a href="#INavigable">INavigable</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/markdown.ts#L44" target="_blank" title="View source">#</a></small></code></h2><p>An <code>@#+</code> tag belongs to a specific page.</p>
+        <h2 class="interface-title"><code><small>interface</small> IHeadingNode<small> extends <a href="#INavigable">INavigable</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/markdown.ts#L44" target="_blank" title="View source">#</a></small></code></h2><p>An <code>@#+</code> tag belongs to a specific page.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1010,7 +1010,7 @@ tracing <code>@page</code> and <code>@#+</code> tags.</p>
     </section>
     <section data-route="IPageNode" hidden="hidden">
       <div class="interface-block" id="IPageNode">
-        <h2 class="interface-title"><code><small>interface</small> IPageNode<small> extends <a href="#IHeadingNode">IHeadingNode</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/markdown.ts#L50" target="_blank" title="View source">#</a></small></code></h2><p>A page has ordered children composed of <code>@#+</code> and <code>@page</code> tags.</p>
+        <h2 class="interface-title"><code><small>interface</small> IPageNode<small> extends <a href="#IHeadingNode">IHeadingNode</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/markdown.ts#L50" target="_blank" title="View source">#</a></small></code></h2><p>A page has ordered children composed of <code>@#+</code> and <code>@page</code> tags.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1066,25 +1066,25 @@ tracing <code>@page</code> and <code>@#+</code> tags.</p>
     </section>
     <section data-route="IPlugin" hidden="hidden">
       <div class="interface-block" id="IPlugin">
-        <h2 class="interface-title"><code><small>interface</small> IPlugin<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/plugin.ts#L37" target="_blank" title="View source">#</a></small></code></h2><p>A Documentalist plugin is an object with a <code>compile(files, compiler)</code> function
+        <h2 class="interface-title"><code><small>interface</small> IPlugin<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/plugin.ts#L37" target="_blank" title="View source">#</a></small></code></h2><p>A Documentalist plugin is an object with a <code>compile(files, compiler)</code> function
 that returns a data object (or a promise for that object).</p>
 <p>A common pattern is to define a class that implements this interface and use the constructor
 to accept options.</p>
-<pre><code class="lang-ts"><span class="hljs-keyword">import</span> { ICompiler, IFile, IPlugin } <span class="hljs-keyword">from</span> <span class="hljs-string">"documentalist/client"</span>;
+<pre><code class="lang-ts">import { ICompiler, IFile, IPlugin } from &quot;documentalist/client&quot;;
 
-<span class="hljs-keyword">export</span> <span class="hljs-keyword">interface</span> MyData {
+export interface MyData {
     pluginName: { ... }
 }
 
-<span class="hljs-keyword">export</span> <span class="hljs-keyword">interface</span> MyOptions {
+export interface MyOptions {
     ...
 }
 
-<span class="hljs-keyword">export</span> <span class="hljs-keyword">class</span> MyPlugin <span class="hljs-keyword">implements</span> IPlugin&lt;MyData&gt; {
-    <span class="hljs-keyword">public</span> <span class="hljs-keyword">constructor</span>(<span class="hljs-params">options: MyOptions = {}</span>) {}
+export class MyPlugin implements IPlugin&lt;MyData&gt; {
+    public constructor(options: MyOptions = {}) {}
 
-    <span class="hljs-keyword">public</span> compile(files: IFile[], compiler: ICompiler) {
-        <span class="hljs-keyword">return</span> files.map(transformToMyData);
+    public compile(files: IFile[], compiler: ICompiler) {
+        return files.map(transformToMyData);
     }
 }
 </code></pre>
@@ -1106,7 +1106,7 @@ to accept options.</p>
     </section>
     <section data-route="IFile" hidden="hidden">
       <div class="interface-block" id="IFile">
-        <h2 class="interface-title"><code><small>interface</small> IFile<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/plugin.ts#L45" target="_blank" title="View source">#</a></small></code></h2><p>Abstract representation of a file, containing absolute path and synchronous <code>read</code> operation.
+        <h2 class="interface-title"><code><small>interface</small> IFile<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/plugin.ts#L45" target="_blank" title="View source">#</a></small></code></h2><p>Abstract representation of a file, containing absolute path and synchronous <code>read</code> operation.
 This allows plugins to use only the path of a file without reading it.</p>
 
         <h3>Properties</h3>
@@ -1139,7 +1139,7 @@ This allows plugins to use only the path of a file without reading it.</p>
     </section>
     <section data-route="ITsFlags" hidden="hidden">
       <div class="interface-block" id="ITsFlags">
-        <h2 class="interface-title"><code><small>interface</small> ITsFlags<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L25" target="_blank" title="View source">#</a></small></code></h2><p>Compiler flags about this member.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsFlags<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L25" target="_blank" title="View source">#</a></small></code></h2><p>Compiler flags about this member.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1223,7 +1223,7 @@ This allows plugins to use only the path of a file without reading it.</p>
     </section>
     <section data-route="ITsDocBase" hidden="hidden">
       <div class="interface-block" id="ITsDocBase">
-        <h2 class="interface-title"><code><small>interface</small> ITsDocBase<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L39" target="_blank" title="View source">#</a></small></code></h2><p>Base type for all typescript documentation members.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsDocBase<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L39" target="_blank" title="View source">#</a></small></code></h2><p>Base type for all typescript documentation members.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1292,7 +1292,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="INavigable" hidden="hidden">
       <div class="interface-block" id="INavigable">
-        <h2 class="interface-title"><code><small>interface</small> INavigable<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/tags.ts#L21" target="_blank" title="View source">#</a></small></code></h2><p>The basic components of a navigable resource: a &quot;route&quot; at which it can be accessed and
+        <h2 class="interface-title"><code><small>interface</small> INavigable<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/tags.ts#L21" target="_blank" title="View source">#</a></small></code></h2><p>The basic components of a navigable resource: a &quot;route&quot; at which it can be accessed and
 its depth in the layout hierarchy. Heading tags and hierarchy nodes both extend this interface.</p>
 
         <h3>Properties</h3>
@@ -1322,7 +1322,7 @@ its depth in the layout hierarchy. Heading tags and hierarchy nodes both extend 
     </section>
     <section data-route="ITsDefaultValue" hidden="hidden">
       <div class="interface-block" id="ITsDefaultValue">
-        <h2 class="interface-title"><code><small>interface</small> ITsDefaultValue<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L76" target="_blank" title="View source">#</a></small></code></h2><p>Re-usable interface for Typescript members that support a notion of &quot;default value.&quot;</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsDefaultValue<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L76" target="_blank" title="View source">#</a></small></code></h2><p>Re-usable interface for Typescript members that support a notion of &quot;default value.&quot;</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1342,7 +1342,7 @@ its depth in the layout hierarchy. Heading tags and hierarchy nodes both extend 
     </section>
     <section data-route="ITsObjectDefinition" hidden="hidden">
       <div class="interface-block" id="ITsObjectDefinition">
-        <h2 class="interface-title"><code><small>interface</small> ITsObjectDefinition<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L82" target="_blank" title="View source">#</a></small></code></h2><p>Re-usable interface for Typescript members that look like objects.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsObjectDefinition<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L82" target="_blank" title="View source">#</a></small></code></h2><p>Re-usable interface for Typescript members that look like objects.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1398,7 +1398,7 @@ its depth in the layout hierarchy. Heading tags and hierarchy nodes both extend 
     </section>
     <section data-route="ITsConstructor" hidden="hidden">
       <div class="interface-block" id="ITsConstructor">
-        <h2 class="interface-title"><code><small>interface</small> ITsConstructor<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsCallable">ITsCallable</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L99" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a class constructor. See <code>signatures</code> array for actual callable signatures and rendered docs.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsConstructor<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsCallable">ITsCallable</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L99" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a class constructor. See <code>signatures</code> array for actual callable signatures and rendered docs.</p>
 
         <blockquote>
           <p>see: <code><a href="#ITsClass">ITsClass</a></code></p>
@@ -1487,7 +1487,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITsMethod" hidden="hidden">
       <div class="interface-block" id="ITsMethod">
-        <h2 class="interface-title"><code><small>interface</small> ITsMethod<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsCallable">ITsCallable</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L104" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a method. See <code>signatures</code> array for actual callable signatures and rendered docs.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsMethod<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsCallable">ITsCallable</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L104" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a method. See <code>signatures</code> array for actual callable signatures and rendered docs.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1573,7 +1573,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITsSignature" hidden="hidden">
       <div class="interface-block" id="ITsSignature">
-        <h2 class="interface-title"><code><small>interface</small> ITsSignature<small> extends <a href="#ITsDocBase">ITsDocBase</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L112" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a single signature, including parameters, return type, and full type string.
+        <h2 class="interface-title"><code><small>interface</small> ITsSignature<small> extends <a href="#ITsDocBase">ITsDocBase</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L112" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a single signature, including parameters, return type, and full type string.
 Signatures are used for methods and constructors on classes or interfaces, and for index signatures on objects.</p>
 
         <h3>Properties</h3>
@@ -1670,7 +1670,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITsParameter" hidden="hidden">
       <div class="interface-block" id="ITsParameter">
-        <h2 class="interface-title"><code><small>interface</small> ITsParameter<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsDefaultValue">ITsDefaultValue</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L125" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a single parameter to a signature.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsParameter<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsDefaultValue">ITsDefaultValue</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L125" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a single parameter to a signature.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1751,7 +1751,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITsProperty" hidden="hidden">
       <div class="interface-block" id="ITsProperty">
-        <h2 class="interface-title"><code><small>interface</small> ITsProperty<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsDefaultValue">ITsDefaultValue</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L134" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a property of an object, which may have a default value.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsProperty<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsDefaultValue">ITsDefaultValue</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L134" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a property of an object, which may have a default value.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1846,7 +1846,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITsInterface" hidden="hidden">
       <div class="interface-block" id="ITsInterface">
-        <h2 class="interface-title"><code><small>interface</small> ITsInterface<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsObjectDefinition">ITsObjectDefinition</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L143" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for an <code>interface</code> definition.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsInterface<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsObjectDefinition">ITsObjectDefinition</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L143" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for an <code>interface</code> definition.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -1959,7 +1959,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITsClass" hidden="hidden">
       <div class="interface-block" id="ITsClass">
-        <h2 class="interface-title"><code><small>interface</small> ITsClass<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsObjectDefinition">ITsObjectDefinition</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L148" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a <code>class</code> definition.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsClass<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsObjectDefinition">ITsObjectDefinition</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L148" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for a <code>class</code> definition.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -2081,7 +2081,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITsEnumMember" hidden="hidden">
       <div class="interface-block" id="ITsEnumMember">
-        <h2 class="interface-title"><code><small>interface</small> ITsEnumMember<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsDefaultValue">ITsDefaultValue</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L154" target="_blank" title="View source">#</a></small></code></h2><p>A member of an <code>enum</code> definition. An enum member will have a <code>defaultValue</code> if it was declared with an initializer.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsEnumMember<small> extends <a href="#ITsDocBase">ITsDocBase</a>, <a href="#ITsDefaultValue">ITsDefaultValue</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L154" target="_blank" title="View source">#</a></small></code></h2><p>A member of an <code>enum</code> definition. An enum member will have a <code>defaultValue</code> if it was declared with an initializer.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -2158,7 +2158,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITsEnum" hidden="hidden">
       <div class="interface-block" id="ITsEnum">
-        <h2 class="interface-title"><code><small>interface</small> ITsEnum<small> extends <a href="#ITsDocBase">ITsDocBase</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L159" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for an <code>enum</code> definition.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsEnum<small> extends <a href="#ITsDocBase">ITsDocBase</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L159" target="_blank" title="View source">#</a></small></code></h2><p>Documentation for an <code>enum</code> definition.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -2235,7 +2235,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITsTypeAlias" hidden="hidden">
       <div class="interface-block" id="ITsTypeAlias">
-        <h2 class="interface-title"><code><small>interface</small> ITsTypeAlias<small> extends <a href="#ITsDocBase">ITsDocBase</a></small><small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L166" target="_blank" title="View source">#</a></small></code></h2><p>A type alias, defined using <code>export type {name} = {type}.</code> The <code>type</code> property will contain the full type alias as a string.</p>
+        <h2 class="interface-title"><code><small>interface</small> ITsTypeAlias<small> extends <a href="#ITsDocBase">ITsDocBase</a></small><small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L166" target="_blank" title="View source">#</a></small></code></h2><p>A type alias, defined using <code>export type {name} = {type}.</code> The <code>type</code> property will contain the full type alias as a string.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -2312,7 +2312,7 @@ Otherwise, it will reference the current commit hash.</p>
     </section>
     <section data-route="ITypescriptPluginData" hidden="hidden">
       <div class="interface-block" id="ITypescriptPluginData">
-        <h2 class="interface-title"><code><small>interface</small> ITypescriptPluginData<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L179" target="_blank" title="View source">#</a></small></code></h2><p>The <code>TypescriptPlugin</code> exports a <code>typescript</code> key that contains a map of member name to
+        <h2 class="interface-title"><code><small>interface</small> ITypescriptPluginData<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L179" target="_blank" title="View source">#</a></small></code></h2><p>The <code>TypescriptPlugin</code> exports a <code>typescript</code> key that contains a map of member name to
 <code>class</code> or <code>interface</code> definition.</p>
 <p>Only classes and interfaces are provided at this root level, but each member contains full
 information about its children, such as methods (and signatures and parameters) and properties.</p>
@@ -2334,7 +2334,7 @@ information about its children, such as methods (and signatures and parameters) 
     </section>
     <section data-route="ICompilerOptions" hidden="hidden">
       <div class="interface-block" id="ICompilerOptions">
-        <h2 class="interface-title"><code><small>interface</small> ICompilerOptions<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/compiler.ts#L24" target="_blank" title="View source">#</a></small></code></h2>
+        <h2 class="interface-title"><code><small>interface</small> ICompilerOptions<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/compiler.ts#L24" target="_blank" title="View source">#</a></small></code></h2>
         <h3>Properties</h3>
         <div class="interface-properties">
           <table>
@@ -2364,7 +2364,7 @@ Do not include the <code>@</code> prefix in the strings.</p>
     </section>
     <section data-route="IPluginEntry" hidden="hidden">
       <div class="interface-block" id="IPluginEntry">
-        <h2 class="interface-title"><code><small>interface</small> IPluginEntry<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/documentalist.ts#L17" target="_blank" title="View source">#</a></small></code></h2><p>Plugins are stored with the regex used to match against file paths.</p>
+        <h2 class="interface-title"><code><small>interface</small> IPluginEntry<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/documentalist.ts#L17" target="_blank" title="View source">#</a></small></code></h2><p>Plugins are stored with the regex used to match against file paths.</p>
 
         <h3>Properties</h3>
         <div class="interface-properties">
@@ -2391,7 +2391,7 @@ Do not include the <code>@</code> prefix in the strings.</p>
     </section>
     <section data-route="IMarkdownPluginOptions" hidden="hidden">
       <div class="interface-block" id="IMarkdownPluginOptions">
-        <h2 class="interface-title"><code><small>interface</small> IMarkdownPluginOptions<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/plugins/markdown.ts#L24" target="_blank" title="View source">#</a></small></code></h2>
+        <h2 class="interface-title"><code><small>interface</small> IMarkdownPluginOptions<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/plugins/markdown.ts#L24" target="_blank" title="View source">#</a></small></code></h2>
         <h3>Properties</h3>
         <div class="interface-properties">
           <table>
@@ -2410,7 +2410,7 @@ Do not include the <code>@</code> prefix in the strings.</p>
     </section>
     <section data-route="ITypescriptPluginOptions" hidden="hidden">
       <div class="interface-block" id="ITypescriptPluginOptions">
-        <h2 class="interface-title"><code><small>interface</small> ITypescriptPluginOptions<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/plugins/typescript/index.ts#L14" target="_blank" title="View source">#</a></small></code></h2>
+        <h2 class="interface-title"><code><small>interface</small> ITypescriptPluginOptions<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/plugins/typescript/index.ts#L14" target="_blank" title="View source">#</a></small></code></h2>
         <h3>Properties</h3>
         <div class="interface-properties">
           <table>
@@ -2503,7 +2503,7 @@ Note that compiler errors are ignored by Typedoc so they do not affect docs gene
     </section>
     <section data-route="Kind" hidden="hidden">
       <div class="interface-block" id="Kind">
-        <h2 class="interface-title"><code><small>enum</small> Kind<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/typescript.ts#L11" target="_blank" title="View source">#</a></small></code></h2><p>Enumeration describing the various kinds of member supported by this plugin.</p>
+        <h2 class="interface-title"><code><small>enum</small> Kind<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/typescript.ts#L11" target="_blank" title="View source">#</a></small></code></h2><p>Enumeration describing the various kinds of member supported by this plugin.</p>
 
         <h3>Members</h3>
         <div class="interface-properties">
@@ -2594,7 +2594,7 @@ Note that compiler errors are ignored by Typedoc so they do not affect docs gene
     </section>
     <section data-route="StringOrTag" hidden="hidden">
       <div class="interface-block" id="StringOrTag">
-        <h2 class="interface-title"><code><small>type alias</small> StringOrTag<small> <a href="https://github.com/palantir/documentalist/blob/919ab2a/src/client/tags.ts#L42" target="_blank" title="View source">#</a></small></code></h2>
+        <h2 class="interface-title"><code><small>type alias</small> StringOrTag<small> <a href="https://github.com/palantir/documentalist/blob/02176b1/src/client/tags.ts#L42" target="_blank" title="View source">#</a></small></code></h2>
         <div class="interface-properties">
           <table>
             <tr>

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "js-yaml": "^3.10.0",
     "kss": "^3.0.0-beta.18",
     "marked": "^0.3.7",
-    "typedoc": "^0.9.0",
+    "typedoc": "^0.10.0",
     "yargs": "^10.0.3"
   },
   "devDependencies": {
-    "@blueprintjs/tslint-config": "^1.0.1",
+    "@blueprintjs/tslint-config": "^1.1.0",
     "@types/glob": "^5.0.30",
     "@types/jest": "^21.1.8",
     "@types/js-yaml": "^3.10.1",
@@ -43,8 +43,8 @@
     "pug-cli": "^1.0.0-alpha6",
     "ts-jest": "^22.0.0",
     "ts-node": "^4.0.2",
-    "tslint": "^5.8.0",
-    "typescript": "^2.6.2"
+    "tslint": "^5.9.1",
+    "typescript": "^2.7.2"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@blueprintjs/tslint-config@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@blueprintjs/tslint-config/-/tslint-config-1.0.1.tgz#983193302784d733a377bd8049e1e90d22b1247a"
+"@blueprintjs/tslint-config@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/tslint-config/-/tslint-config-1.1.0.tgz#bb8b083263eca039893b6ecd1553022c9ef55239"
   dependencies:
     prettier "^1.7.4"
     tslint "^5.7.0"
@@ -24,10 +24,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
 
-"@types/fs-extra@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"
+"@types/fs-extra@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.0.tgz#d3e225b35eb5c6d3a5a782c28219df365c781413"
   dependencies:
+    "@types/node" "*"
+
+"@types/glob@*":
+  version "5.0.35"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.35.tgz#1ae151c802cece940443b5ac246925c85189f32a"
+  dependencies:
+    "@types/events" "*"
+    "@types/minimatch" "*"
     "@types/node" "*"
 
 "@types/glob@^5.0.30":
@@ -38,13 +46,13 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/handlebars@4.0.31":
-  version "4.0.31"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.31.tgz#a7fba66fafe42713aee88eeca8db91192efe6e72"
+"@types/handlebars@4.0.36":
+  version "4.0.36"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"
 
-"@types/highlight.js@9.1.8":
-  version "9.1.8"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.1.8.tgz#d227f18bcb8f3f187e16965f2444859a04689758"
+"@types/highlight.js@9.12.2":
+  version "9.12.2"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.2.tgz#6ee7cd395effe5ec80b515d3ff1699068cd0cd1d"
 
 "@types/jest@^21.1.8":
   version "21.1.8"
@@ -58,9 +66,9 @@
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/kss/-/kss-3.0.0.tgz#8456ebcaccfd70fb7396033d9416bda710e56b95"
 
-"@types/lodash@4.14.74":
-  version "4.14.74"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.74.tgz#ac3bd8db988e7f7038e5d22bd76a7ba13f876168"
+"@types/lodash@4.14.99":
+  version "4.14.99"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.99.tgz#e6e10c0a4cc16c7409b3181f1e66880d2fb7d4dc"
 
 "@types/marked@0.3.0", "@types/marked@^0.3.0":
   version "0.3.0"
@@ -70,18 +78,19 @@
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.2.tgz#09c06877e478a5d5f32ce5017c2eb2b33006f6f5"
 
-"@types/minimatch@2.0.29":
-  version "2.0.29"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-2.0.29.tgz#5002e14f75e2d71e564281df0431c8c1b4a2a36a"
+"@types/minimatch@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
 "@types/node@*", "@types/node@^8.5.1":
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.5.1.tgz#4ec3020bcdfe2abffeef9ba3fbf26fca097514b5"
 
-"@types/shelljs@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.0.tgz#229c157c6bc1e67d6b990e6c5e18dbd2ff58cff0"
+"@types/shelljs@0.7.7":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.7.tgz#1f7bfa28947661afea06365db9b1135bbc903ec4"
   dependencies:
+    "@types/glob" "*"
     "@types/node" "*"
 
 "@types/strip-bom@^3.0.0":
@@ -660,6 +669,10 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.12.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
+
 commander@^2.8.1, commander@^2.9.0:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
@@ -1063,7 +1076,7 @@ from@~0:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
-fs-extra@4.0.3, fs-extra@^4.0.0:
+fs-extra@4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
   dependencies:
@@ -1077,6 +1090,14 @@ fs-extra@^2.0.0:
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
+
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2038,7 +2059,11 @@ map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
 
-marked@^0.3.5, marked@^0.3.6, marked@^0.3.7:
+marked@^0.3.12:
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.17.tgz#607f06668b3c6b1246b28f13da76116ac1aa2d2b"
+
+marked@^0.3.6, marked@^0.3.7:
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.7.tgz#80ef3bbf1bd00d1c9cfebe42ba1b8c85da258d0d"
 
@@ -2837,9 +2862,9 @@ shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
-shelljs@^0.7.0:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+shelljs@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.1.tgz#729e038c413a2254c4078b95ed46e0397154a9f1"
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"
@@ -3170,7 +3195,7 @@ tslint-react@^3.2.0:
   dependencies:
     tsutils "^2.8.0"
 
-tslint@^5.7.0, tslint@^5.8.0:
+tslint@^5.7.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.8.0.tgz#1f49ad5b2e77c76c3af4ddcae552ae4e3612eb13"
   dependencies:
@@ -3184,6 +3209,23 @@ tslint@^5.7.0, tslint@^5.8.0:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.7.1"
+    tsutils "^2.12.1"
+
+tslint@^5.9.1:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    builtin-modules "^1.1.1"
+    chalk "^2.3.0"
+    commander "^2.12.1"
+    diff "^3.2.0"
+    glob "^7.1.1"
+    js-yaml "^3.7.0"
+    minimatch "^3.0.4"
+    resolve "^1.3.2"
+    semver "^5.3.0"
+    tslib "^1.8.0"
     tsutils "^2.12.1"
 
 tsutils@^2.12.1, tsutils@^2.8.0:
@@ -3220,35 +3262,35 @@ typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
 
-typedoc@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.9.0.tgz#159bff7c7784ce5b91d86f3e4cc8928e62040957"
+typedoc@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.10.0.tgz#898b447248dabf68ecbde9d5ccf5141fda8aa166"
   dependencies:
-    "@types/fs-extra" "4.0.0"
-    "@types/handlebars" "4.0.31"
-    "@types/highlight.js" "9.1.8"
-    "@types/lodash" "4.14.74"
+    "@types/fs-extra" "5.0.0"
+    "@types/handlebars" "4.0.36"
+    "@types/highlight.js" "9.12.2"
+    "@types/lodash" "4.14.99"
     "@types/marked" "0.3.0"
-    "@types/minimatch" "2.0.29"
-    "@types/shelljs" "0.7.0"
-    fs-extra "^4.0.0"
+    "@types/minimatch" "3.0.3"
+    "@types/shelljs" "0.7.7"
+    fs-extra "^5.0.0"
     handlebars "^4.0.6"
     highlight.js "^9.0.0"
     lodash "^4.13.1"
-    marked "^0.3.5"
+    marked "^0.3.12"
     minimatch "^3.0.0"
     progress "^2.0.0"
-    shelljs "^0.7.0"
+    shelljs "^0.8.1"
     typedoc-default-themes "^0.5.0"
-    typescript "2.4.1"
+    typescript "2.7.1"
 
-typescript@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
+typescript@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
-typescript@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
 
 uglify-js@^2.6, uglify-js@^2.6.1:
   version "2.8.29"


### PR DESCRIPTION
typedoc 0.10.0 now supports typescript 2.7!
this is not a breaking change, can be shipped as 1.1.0.