### PR TITLE
NPM plugin

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,7 +13,7 @@
 const yargs = require("yargs");
 const fs = require("fs");
 const glob = require("glob");
-const { Documentalist, KssPlugin, MarkdownPlugin, TypescriptPlugin } = require("./dist/");
+const { Documentalist, KssPlugin, MarkdownPlugin, NpmPlugin, TypescriptPlugin } = require("./dist/");
 
 const argv = yargs
     .alias("v", "version")
@@ -23,6 +23,11 @@ const argv = yargs
     .option("md", {
         default: true,
         desc: "use MarkdownPlugin for .md files",
+        type: "boolean",
+    })
+    .option("npm", {
+        default: true,
+        desc: "use NPM plugin for package.json files",
         type: "boolean",
     })
     .option("ts", {
@@ -41,6 +46,9 @@ let docs = Documentalist.create();
 
 if (argv.md) {
     docs = docs.use(".md", new MarkdownPlugin());
+}
+if (argv.npm) {
+    docs = docs.use("package.json", new NpmPlugin());
 }
 if (argv.ts) {
     docs = docs.use(/\.tsx?$/, new TypescriptPlugin({ excludePaths: ["__tests__/"] }));

--- a/src/__tests__/npm.test.ts
+++ b/src/__tests__/npm.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain
+ * a copy of the license in the LICENSE and PATENTS files in the root of this
+ * repository.
+ */
+
+import { Documentalist } from "../documentalist";
+import { NpmPlugin } from "../plugins/npm";
+
+describe("NpmPlugin", () => {
+    const dm = Documentalist.create().use("package.json", new NpmPlugin());
+
+    it("npm info matches package.json", async () => {
+        const { npm: { documentalist } } = await dm.documentGlobs("package.json");
+        const pkg = require("../../package.json");
+        // NOTE: not using snapshot as it would change with every release due to `npm info` call.
+        expect(documentalist.name).toBe(pkg.name);
+        expect(documentalist.description).toBe(pkg.description);
+        expect(documentalist.nextVersion || documentalist.latestVersion).toBe(pkg.version);
+    });
+});

--- a/src/client/compiler.ts
+++ b/src/client/compiler.ts
@@ -18,6 +18,11 @@ export interface ICompiler {
     objectify<T>(array: T[], getKey: (item: T) => string): { [key: string]: T };
 
     /**
+     * Get the relative path from `sourceBaseDir` to the given path.
+     */
+    relativePath(path: string): string;
+
+    /**
      * Render a block of content by extracting metadata (YAML front matter) and
      * splitting text content into markdown-rendered HTML strings and `{ tag,
      * value }` objects.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -18,6 +18,7 @@
 export * from "./compiler";
 export * from "./kss";
 export * from "./markdown";
+export * from "./npm";
 export * from "./plugin";
 export * from "./tags";
 export * from "./typescript";

--- a/src/client/npm.ts
+++ b/src/client/npm.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018-present Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain
+ * a copy of the license in the LICENSE and PATENTS files in the root of this
+ * repository.
+ */
+
+/**
+ * Version information about an NPM package.
+ */
+export interface INpmPackage {
+    /** Latest version of the package (npm `latest` tag). */
+    latestVersion: string;
+
+    /** Most recent release of each major version of this package. */
+    majorVersions: string[];
+
+    /** Name of package */
+    name: string;
+
+    /** Next version of the package (npm `next` tag). */
+    nextVersion: string;
+}
+
+/**
+ * The `KssPlugin` exports a `css` key that contains a map of styleguide references to markup/modifier examples.
+ *
+ * @see KSSPlugin
+ */
+export interface INpmPluginData {
+    npm: {
+        [packageName: string]: INpmPackage;
+    };
+}

--- a/src/client/npm.ts
+++ b/src/client/npm.ts
@@ -9,17 +9,20 @@
  * Version information about an NPM package.
  */
 export interface INpmPackage {
-    /** Latest version of the package (npm `latest` tag). */
-    latestVersion: string;
+    /** Package description. */
+    description?: string;
 
-    /** Most recent release of each major version of this package. */
-    majorVersions: string[];
+    /** Latest version of the package (npm `latest` dist-tag). */
+    latestVersion?: string;
 
-    /** Name of package */
+    /** Package name. */
     name: string;
 
-    /** Next version of the package (npm `next` tag). */
-    nextVersion: string;
+    /** Next version of the package (npm `next` dist-tag). */
+    nextVersion?: string;
+
+    /** All published versions of this package. */
+    versions: string[];
 }
 
 /**

--- a/src/client/npm.ts
+++ b/src/client/npm.ts
@@ -21,7 +21,7 @@ export interface INpmPackage {
     /** Next version of the package (npm `next` dist-tag). */
     nextVersion?: string;
 
-    /** Relative path from cwd to the package directory. */
+    /** Relative path from `sourceBaseDir` to this package. */
     sourcePath: string;
 
     /** All published versions of this package. */

--- a/src/client/npm.ts
+++ b/src/client/npm.ts
@@ -5,21 +5,24 @@
  * repository.
  */
 
-/**
- * Version information about an NPM package.
- */
 export interface INpmPackage {
+    /** Package name. */
+    name: string;
+
     /** Package description. */
     description?: string;
 
     /** Latest version of the package (npm `latest` dist-tag). */
-    latestVersion?: string;
-
-    /** Package name. */
-    name: string;
+    latestVersion: string;
 
     /** Next version of the package (npm `next` dist-tag). */
     nextVersion?: string;
+
+    /** Whether this package is marked `private`. */
+    private: boolean;
+
+    /** Whether this package is published to NPM. */
+    published: boolean;
 
     /** Relative path from `sourceBaseDir` to this package. */
     sourcePath: string;

--- a/src/client/npm.ts
+++ b/src/client/npm.ts
@@ -21,6 +21,9 @@ export interface INpmPackage {
     /** Next version of the package (npm `next` dist-tag). */
     nextVersion?: string;
 
+    /** Relative path from cwd to the package directory. */
+    sourcePath: string;
+
     /** All published versions of this package. */
     versions: string[];
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -53,10 +53,10 @@ export class Compiler implements ICompiler {
         }, {});
     }
 
-    public relativePath(path: string) {
+    public relativePath = (path: string) => {
         const { sourceBaseDir = process.cwd() } = this.options;
         return relative(sourceBaseDir, path);
-    }
+    };
 
     public renderBlock = (blockContent: string, reservedTagWords = this.options.reservedTags): IBlock => {
         const { contentsRaw, metadata } = this.extractMetadata(blockContent.trim());

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -7,6 +7,7 @@
 
 import * as yaml from "js-yaml";
 import * as marked from "marked";
+import { relative } from "path";
 import { IBlock, ICompiler, IHeadingTag, StringOrTag } from "./client";
 
 /**
@@ -31,6 +32,15 @@ export interface ICompilerOptions {
      * Do not include the `@` prefix in the strings.
      */
     reservedTags?: string[];
+
+    /**
+     * Base directory for generating relative `sourcePath`s.
+     *
+     * This option _does not affect_ glob expansion, only the generation of
+     * `sourcePath` in plugin data.
+     * @default process.cwd()
+     */
+    sourceBaseDir?: string;
 }
 
 export class Compiler implements ICompiler {
@@ -41,6 +51,11 @@ export class Compiler implements ICompiler {
             obj[getKey(item)] = item;
             return obj;
         }, {});
+    }
+
+    public relativePath(path: string) {
+        const { sourceBaseDir = process.cwd() } = this.options;
+        return relative(sourceBaseDir, path);
     }
 
     public renderBlock = (blockContent: string, reservedTagWords = this.options.reservedTags): IBlock => {

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -16,7 +16,7 @@ import { TypescriptPlugin } from "./plugins/typescript";
 // Set breakpoints in original .ts source and debug in the editor!
 Documentalist.create()
     .use(".ts", new TypescriptPlugin())
-    .use(".json", new NpmPlugin())
+    .use("package.json", new NpmPlugin())
     .documentGlobs(
         path.join(__dirname, "..", "package.json"),
         // compile test fixtures:

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -7,6 +7,7 @@
 
 import * as path from "path";
 import { Documentalist } from "./documentalist";
+import { NpmPlugin } from "./plugins/npm";
 import { TypescriptPlugin } from "./plugins/typescript";
 
 // Launch "Documentalist" from Debug panel in VS Code (see .vscode/launch.json).
@@ -15,7 +16,9 @@ import { TypescriptPlugin } from "./plugins/typescript";
 // Set breakpoints in original .ts source and debug in the editor!
 Documentalist.create()
     .use(".ts", new TypescriptPlugin())
+    .use(".json", new NpmPlugin())
     .documentGlobs(
+        path.join(__dirname, "..", "package.json"),
         // compile test fixtures:
         path.join(__dirname, "__tests__", "__fixtures__", "*.ts"),
         // compile our own source code:

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -7,4 +7,5 @@
 
 export * from "./kss";
 export * from "./markdown";
+export * from "./npm";
 export * from "./typescript/index";

--- a/src/plugins/kss.ts
+++ b/src/plugins/kss.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import { ICompiler, IFile, IKssExample, IKssModifier, IKssPluginData, IPlugin } from "../client";
 
 /**
- * The `KSSPlugin` extracts [KSS doc comments](http://warpspire.com/kss/syntax/) from CSS code (or similar languages).
+ * The `KssPlugin` extracts [KSS doc comments](http://warpspire.com/kss/syntax/) from CSS code (or similar languages).
  * It emits an object keyed by the "styleguide [ref]" section of the comment. The documentation, markup, and modifiers
  * sections will all be emitted in the data.
  *

--- a/src/plugins/markdown.ts
+++ b/src/plugins/markdown.ts
@@ -64,23 +64,23 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
         return { nav, pages };
     }
 
-    private blockToPage(filePath: string, block: IBlock): IPageData {
-        const reference = getReference(filePath, block);
+    private blockToPage(sourcePath: string, block: IBlock): IPageData {
+        const reference = getReference(sourcePath, block);
         return {
             reference,
             route: reference,
-            sourcePath: path.relative(process.cwd(), filePath),
+            sourcePath,
             title: getTitle(block),
             ...block,
         };
     }
 
     /** Convert each file to IPageData and populate store. */
-    private buildPageStore(markdownFiles: IFile[], { renderBlock }: ICompiler) {
+    private buildPageStore(markdownFiles: IFile[], { relativePath, renderBlock }: ICompiler) {
         const pageMap = new PageMap();
         for (const file of markdownFiles) {
             const block = renderBlock(file.read());
-            const page = this.blockToPage(file.path, block);
+            const page = this.blockToPage(relativePath(file.path), block);
             pageMap.set(page.reference, page);
         }
         return pageMap;

--- a/src/plugins/npm.ts
+++ b/src/plugins/npm.ts
@@ -38,6 +38,8 @@ export class NpmPlugin implements IPlugin<INpmPluginData> {
         const sourcePath = dm.relativePath(packageJson.path);
         const json = JSON.parse(packageJson.read());
         const data = JSON.parse(await this.getNpmInfo(json.name));
+        // `npm info` returns an error if it doesn't know the package
+        // so we can use package.json data instead
         if (data.error) {
             return {
                 name: json.name,

--- a/src/plugins/npm.ts
+++ b/src/plugins/npm.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2018-present Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the BSD-3 License as modified (the “License”); you may obtain
+ * a copy of the license in the LICENSE and PATENTS files in the root of this
+ * repository.
+ */
+
+import { spawn } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import { ICompiler, IFile, INpmPluginData, IPlugin } from "../client";
+
+/**
+ * The `NPMPlugin` extracts [KSS doc comments](http://warpspire.com/kss/syntax/) from CSS code (or similar languages).
+ * It emits an object keyed by the "styleguide [ref]" section of the comment. The documentation, markup, and modifiers
+ * sections will all be emitted in the data.
+ */
+export class NpmPlugin implements IPlugin<INpmPluginData> {
+    public constructor(private options = {}) {}
+
+    public async compile(packageJsons: IFile[], dm: ICompiler): Promise<INpmPluginData> {
+        for (const pkg of packageJsons) {
+            const { name, version } = JSON.parse(pkg.read());
+            const info = await this.getNpmInfo(name);
+            console.log(info);
+        }
+        return { npm: {} };
+    }
+
+    // private generateReleasesData() {
+    //     const packageDirectories = fs
+    //         .readdirSync(PACKAGES_DIR)
+    //         .map(name => path.join(PACKAGES_DIR, name))
+    //         .filter(source => fs.lstatSync(source).isDirectory());
+
+    //     const releases = packageDirectories
+    //         .filter(packagePath => fs.existsSync(path.resolve(packagePath, "package.json")))
+    //         .map(packagePath => require(path.resolve(packagePath, "package.json")))
+    //         // only include non-private projects
+    //         .filter(project => !project.private)
+    //         // just these two fields from package.json:
+    //         .map(({ name, version }) => ({ name, version }));
+
+    //     fs.writeFileSync(path.join(GENERATED_SRC_DIR, DOCS_RELEASES_FILENAME), JSON.stringify(releases, null, 2));
+    // }
+
+    // /**
+    //  * Create a JSON file containing published versions of the documentation
+    //  */
+    // private generateVersionsData() {
+    //     let stdout = "";
+    //     const child = spawn("git", ["tag"]);
+    //     child.stdout.setEncoding("utf8");
+    //     child.stdout.on("data", data => {
+    //         stdout += data;
+    //     });
+    //     child.on("close", () => {
+    //         /** @type {Map<string, string>} */
+    //         const majorVersionMap = stdout
+    //             .split("\n")
+    //             // turn @blueprintjs/core@* tags into version numbers
+    //             .filter(val => /\@blueprintjs\/core\@[1-9]\d*\.\d+\.\d+.*/.test(val))
+    //             .map(val => val.slice("@blueprintjs/core@".length))
+    //             .reduce((map, version) => {
+    //                 const major = semver.major(version);
+    //                 if (!map.has(major) || semver.gt(version, map.get(major))) {
+    //                     map.set(major, version);
+    //                 }
+    //                 return map;
+    //             }, new Map());
+    //         // sort in reverse order (so latest is first)
+    //         const majorVersions = Array.from(majorVersionMap.values()).sort(semver.rcompare);
+
+    //         console.info("[docs-data] Major versions found:", majorVersions.join(", "));
+
+    //         fs.writeFileSync(
+    //             path.join(GENERATED_SRC_DIR, DOCS_VERSIONS_FIELENAME),
+    //             JSON.stringify(strMapToObj(majorVersionMap), null, 2),
+    //         );
+    //     });
+    // }
+
+    private getNpmInfo(packageName: string) {
+        return new Promise<string>(resolve => {
+            let stdout = "";
+            const child = spawn("npm", ["info", packageName]);
+            child.stdout.setEncoding("utf8");
+            child.stdout.on("data", data => {
+                stdout += data;
+            });
+            child.on("close", () => resolve(stdout));
+        });
+    }
+}

--- a/src/plugins/npm.ts
+++ b/src/plugins/npm.ts
@@ -6,89 +6,51 @@
  */
 
 import { spawn } from "child_process";
-import * as fs from "fs";
-import * as path from "path";
-import { ICompiler, IFile, INpmPluginData, IPlugin } from "../client";
+import { ICompiler, IFile, INpmPackage, INpmPluginData, IPlugin } from "../client";
 
 /**
- * The `NPMPlugin` extracts [KSS doc comments](http://warpspire.com/kss/syntax/) from CSS code (or similar languages).
- * It emits an object keyed by the "styleguide [ref]" section of the comment. The documentation, markup, and modifiers
- * sections will all be emitted in the data.
+ * The `NpmPlugin` parses `package.json` files and emits data about each
+ * NPM package.
  */
 export class NpmPlugin implements IPlugin<INpmPluginData> {
-    public constructor(private options = {}) {}
-
-    public async compile(packageJsons: IFile[], dm: ICompiler): Promise<INpmPluginData> {
-        for (const pkg of packageJsons) {
-            const { name, version } = JSON.parse(pkg.read());
-            const info = await this.getNpmInfo(name);
-            console.log(info);
-        }
-        return { npm: {} };
+    public async compile(packageJsons: IFile[], _dm: ICompiler): Promise<INpmPluginData> {
+        const npm = await Promise.all<string>(
+            // resolve promises in parallel
+            packageJsons
+                .map(pkg => JSON.parse(pkg.read()))
+                .filter(json => json.private !== true)
+                .map(json => this.getNpmInfo(json.name)),
+        )
+            .then(infos => infos.map(this.parseNpmInfo))
+            .then(infos => arrayToObject(infos, pkg => pkg.name));
+        return { npm };
     }
-
-    // private generateReleasesData() {
-    //     const packageDirectories = fs
-    //         .readdirSync(PACKAGES_DIR)
-    //         .map(name => path.join(PACKAGES_DIR, name))
-    //         .filter(source => fs.lstatSync(source).isDirectory());
-
-    //     const releases = packageDirectories
-    //         .filter(packagePath => fs.existsSync(path.resolve(packagePath, "package.json")))
-    //         .map(packagePath => require(path.resolve(packagePath, "package.json")))
-    //         // only include non-private projects
-    //         .filter(project => !project.private)
-    //         // just these two fields from package.json:
-    //         .map(({ name, version }) => ({ name, version }));
-
-    //     fs.writeFileSync(path.join(GENERATED_SRC_DIR, DOCS_RELEASES_FILENAME), JSON.stringify(releases, null, 2));
-    // }
-
-    // /**
-    //  * Create a JSON file containing published versions of the documentation
-    //  */
-    // private generateVersionsData() {
-    //     let stdout = "";
-    //     const child = spawn("git", ["tag"]);
-    //     child.stdout.setEncoding("utf8");
-    //     child.stdout.on("data", data => {
-    //         stdout += data;
-    //     });
-    //     child.on("close", () => {
-    //         /** @type {Map<string, string>} */
-    //         const majorVersionMap = stdout
-    //             .split("\n")
-    //             // turn @blueprintjs/core@* tags into version numbers
-    //             .filter(val => /\@blueprintjs\/core\@[1-9]\d*\.\d+\.\d+.*/.test(val))
-    //             .map(val => val.slice("@blueprintjs/core@".length))
-    //             .reduce((map, version) => {
-    //                 const major = semver.major(version);
-    //                 if (!map.has(major) || semver.gt(version, map.get(major))) {
-    //                     map.set(major, version);
-    //                 }
-    //                 return map;
-    //             }, new Map());
-    //         // sort in reverse order (so latest is first)
-    //         const majorVersions = Array.from(majorVersionMap.values()).sort(semver.rcompare);
-
-    //         console.info("[docs-data] Major versions found:", majorVersions.join(", "));
-
-    //         fs.writeFileSync(
-    //             path.join(GENERATED_SRC_DIR, DOCS_VERSIONS_FIELENAME),
-    //             JSON.stringify(strMapToObj(majorVersionMap), null, 2),
-    //         );
-    //     });
-    // }
 
     private getNpmInfo(packageName: string) {
         return new Promise<string>(resolve => {
             let stdout = "";
-            const child = spawn("npm", ["info", packageName]);
+            const child = spawn("npm", ["info", "--json", packageName]);
             child.stdout.setEncoding("utf8");
-            child.stdout.on("data", data => {
-                stdout += data;
-            });
+            child.stdout.on("data", data => (stdout += data));
             child.on("close", () => resolve(stdout));
         });
     }
+
+    private parseNpmInfo(info: string): INpmPackage {
+        const data = JSON.parse(info);
+        return {
+            name: data.name,
+            // tslint:disable-next-line:object-literal-sort-keys
+            description: data.description,
+            latestVersion: data["dist-tags"].latest,
+            nextVersion: data["dist-tags"].next,
+            versions: data.versions,
+        };
+    }
+}
+
+function arrayToObject<T>(array: T[], keyFn: ((item: T) => string)) {
+    const obj: { [key: string]: T } = {};
+    array.forEach(item => (obj[keyFn(item)] = item));
+    return obj;
 }

--- a/src/plugins/npm.ts
+++ b/src/plugins/npm.ts
@@ -6,25 +6,37 @@
  */
 
 import { spawn } from "child_process";
+import { relative } from "path";
 import { ICompiler, IFile, INpmPackage, INpmPluginData, IPlugin } from "../client";
 
 /**
  * The `NpmPlugin` parses `package.json` files and emits data about each
- * NPM package.
+ * NPM package. Packages marked `private: true` will be ignored.
  */
 export class NpmPlugin implements IPlugin<INpmPluginData> {
     public async compile(packageJsons: IFile[], _dm: ICompiler): Promise<INpmPluginData> {
-        const npm = await Promise.all<string>(
-            // resolve promises in parallel
-            packageJsons
-                .map(pkg => JSON.parse(pkg.read()))
-                .filter(json => json.private !== true)
-                .map(json => this.getNpmInfo(json.name)),
-        )
-            .then(infos => infos.map(this.parseNpmInfo))
-            .then(infos => arrayToObject(infos, pkg => pkg.name));
+        const info = await Promise.all(packageJsons.map(this.parseNpmInfo));
+        const npm = arrayToObject(info.filter(isDefined), pkg => pkg.name);
         return { npm };
     }
+
+    private parseNpmInfo = async (packageJson: IFile): Promise<INpmPackage | undefined> => {
+        const json = JSON.parse(packageJson.read());
+        if (json.private === true) {
+            // ignore private packages as they will not appear in `npm info`
+            return undefined;
+        }
+        const data = JSON.parse(await this.getNpmInfo(json.name));
+        return {
+            name: data.name,
+            // tslint:disable-next-line:object-literal-sort-keys
+            description: data.description,
+            latestVersion: data["dist-tags"].latest,
+            nextVersion: data["dist-tags"].next,
+            sourcePath: relative(process.cwd(), packageJson.path),
+            versions: data.versions,
+        };
+    };
 
     private getNpmInfo(packageName: string) {
         return new Promise<string>(resolve => {
@@ -35,22 +47,14 @@ export class NpmPlugin implements IPlugin<INpmPluginData> {
             child.on("close", () => resolve(stdout));
         });
     }
-
-    private parseNpmInfo(info: string): INpmPackage {
-        const data = JSON.parse(info);
-        return {
-            name: data.name,
-            // tslint:disable-next-line:object-literal-sort-keys
-            description: data.description,
-            latestVersion: data["dist-tags"].latest,
-            nextVersion: data["dist-tags"].next,
-            versions: data.versions,
-        };
-    }
 }
 
 function arrayToObject<T>(array: T[], keyFn: ((item: T) => string)) {
     const obj: { [key: string]: T } = {};
     array.forEach(item => (obj[keyFn(item)] = item));
     return obj;
+}
+
+function isDefined<T>(arg: T | undefined): arg is T {
+    return arg !== undefined;
 }

--- a/src/plugins/npm.ts
+++ b/src/plugins/npm.ts
@@ -26,12 +26,13 @@ export class NpmPlugin implements IPlugin<INpmPluginData> {
             return undefined;
         }
         const data = JSON.parse(await this.getNpmInfo(json.name));
+        const distTags = data["dist-tags"] || {};
         return {
             name: data.name,
             // tslint:disable-next-line:object-literal-sort-keys
             description: data.description,
-            latestVersion: data["dist-tags"].latest,
-            nextVersion: data["dist-tags"].next,
+            latestVersion: distTags.latest,
+            nextVersion: distTags.next,
             sourcePath: dm.relativePath(packageJson.path),
             versions: data.versions,
         };


### PR DESCRIPTION
- new `sourceBaseDir` option for `Documentalist` controls relative pathing for `sourcePath` in MD and NPM
- new `NpmPlugin`!
  - `excludePrivate`, `excludePaths` options
  - parses package.json files, gets more data from `npm info` if possible (async call to npm registry)
     - if package is private or unpublished then it uses available package.json
  - emits name, desc, latest/next, all versions

