### PR TITLE
little docs site fixes

### DIFF
--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -64,7 +64,7 @@ function selectCurrent(route: string) {
     }
 }
 
-const router = new Router(document.querySelector<HTMLElement>("#content")!, "docs");
+const router = new Router(document.querySelector<HTMLElement>("#content")!, "overview");
 const routables = queryAll(document.body, "[data-route]");
 routables.forEach(routable => {
     const route = routable.getAttribute("data-route")!;

--- a/packages/docs/theme/index.pug
+++ b/packages/docs/theme/index.pug
@@ -3,7 +3,7 @@ include mixins
 - var toc = Object.keys(typescript).sort((a, b) => a.localeCompare(b))
 
 mixin listing(title, kind)
-  h3= title
+  h4= title
   each id in toc.filter(a => typescript[a].kind === kind)
     - var name = typescript[id].name
     a.nav-item(href='#' + name): code= name
@@ -17,6 +17,7 @@ html
       each item in nav
         h3: a(href="#" + item.reference)= item.title
 
+      h3 API Reference
       +listing("Classes", "class")
       +listing("Interfaces", "interface")
       +listing("Enums", "enum")

--- a/packages/docs/theme/mixins.pug
+++ b/packages/docs/theme/mixins.pug
@@ -28,12 +28,13 @@ mixin linkify(text = "")
 
 //- renders an `@tag` from a (short) known list
 mixin renderTag(tag, value)
-  blockquote
-    case tag
-      when "interface"
-        +interfaceDocs(typescript[value])
-      default
-        p #{tag}: #[code: +linkify(value)]
+  case tag
+    when "heading"
+      h1= value
+    when "interface"
+      +interfaceDocs(typescript[value])
+    default
+      p #{tag}: #[code: +linkify(value)]
 
 //- render a type signature, including default value & inherited from
 mixin renderType(sig)
@@ -50,7 +51,7 @@ mixin renderType(sig)
 
 //- render docs for an interface (or class) member
 mixin interfaceDocs(iface)
-  .interface-block(id=iface.name)
+  blockquote.interface-block(id=iface.name)
     h2.interface-title
       code #[small= iface.kind] #{iface.name}
         if iface.extends

--- a/packages/docs/theme/mixins.pug
+++ b/packages/docs/theme/mixins.pug
@@ -63,6 +63,9 @@ mixin interfaceDocs(iface)
         small= " "
           a(href=iface.sourceUrl,target="_blank",title="View source") #
 
+    em
+      small= "Exported from: "
+      code @documentalist/#{iface.fileName.split("/", 2)[1]}
 
     if iface.kind === "type alias"
       .interface-properties


### PR DESCRIPTION
hi folks! monorepo change is very nice 👍
was poking through the docs and decided to file down a few rough edges.

- fix ID for the default page so it doesn't load blank
- add "API Reference" heading to separate docs page (Compiler/Client) from list of entity names
- support heading tag to fix the first line of Compiler & Client pages
- add package name to interface docs to clarify where an entity can be found

![Documentalist](https://user-images.githubusercontent.com/464822/56702529-4f7bb100-66b9-11e9-98f8-52503afa4d98.png)

