### PR TITLE
Upgrade typescript, swap typedoc dep

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -12,7 +12,7 @@
     },
     "devDependencies": {
         "tslint": "^5.15.0",
-        "typescript": "~3.3.4000"
+        "typescript": "~3.5.2"
     },
     "engines": {
         "node": ">=8.15.1"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -23,7 +23,7 @@
         "js-yaml": "^3.12.0",
         "kss": "^3.0.0-beta.25",
         "marked": "^0.7.0",
-        "typedoc": "^0.15.0-0",
+        "@gerrit0/typedoc": "^0.15.2",
         "yargs": "^12.0.2"
     },
     "devDependencies": {
@@ -40,7 +40,7 @@
         "ts-jest": "^23.10.3",
         "ts-node": "^7.0.1",
         "tslint": "^5.15.0",
-        "typescript": "~3.3.4000"
+        "typescript": "~3.5.2"
     },
     "engines": {
         "node": ">=8.15.1"

--- a/packages/compiler/src/documentalist.ts
+++ b/packages/compiler/src/documentalist.ts
@@ -119,8 +119,8 @@ export class Documentalist<T> {
      */
     private mergeInto(destination: T, source: T) {
         for (const key in source) {
-            if (source.hasOwnProperty(key)) {
-                if (destination.hasOwnProperty(key)) {
+            if (source[key] != null) {
+                if (destination[key] != null) {
                     console.warn(`WARNING: Duplicate plugin key "${key}". Your plugins are overwriting each other.`);
                 }
                 destination[key] = source[key];

--- a/packages/compiler/src/plugins/typescript/index.ts
+++ b/packages/compiler/src/plugins/typescript/index.ts
@@ -15,7 +15,7 @@
  */
 
 import { ICompiler, IFile, IPlugin, ITypescriptPluginData } from "@documentalist/client";
-import { Application } from "typedoc";
+import { Application } from "@gerrit0/typedoc";
 import { Visitor } from "./visitor";
 
 export { ITypescriptPluginData };

--- a/packages/compiler/src/plugins/typescript/typestring.ts
+++ b/packages/compiler/src/plugins/typescript/typestring.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SignatureReflection } from "typedoc";
+import { SignatureReflection } from "@gerrit0/typedoc";
 import {
     IntersectionType,
     ReferenceType,
@@ -22,7 +22,7 @@ import {
     ReflectionType,
     Type,
     UnionType,
-} from "typedoc/dist/lib/models";
+} from "@gerrit0/typedoc/dist/lib/models";
 
 export function resolveTypeString(type: Type | undefined): string {
     if (type instanceof ReflectionType) {

--- a/packages/compiler/src/plugins/typescript/visitor.ts
+++ b/packages/compiler/src/plugins/typescript/visitor.ts
@@ -30,7 +30,6 @@ import {
     ITsTypeAlias,
     Kind,
 } from "@documentalist/client";
-import { relative } from "path";
 import {
     DeclarationReflection,
     ParameterReflection,
@@ -38,9 +37,10 @@ import {
     Reflection,
     ReflectionKind,
     SignatureReflection,
-} from "typedoc";
-import { Comment, UnionType } from "typedoc/dist/lib/models";
-import { DefaultValueContainer } from "typedoc/dist/lib/models/reflections/abstract";
+} from "@gerrit0/typedoc";
+import { Comment, UnionType } from "@gerrit0/typedoc/dist/lib/models";
+import { DefaultValueContainer } from "@gerrit0/typedoc/dist/lib/models/reflections/abstract";
+import { relative } from "path";
 import { ITypescriptPluginOptions } from "./index";
 import { resolveSignature, resolveTypeString } from "./typestring";
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -20,7 +20,7 @@
         "npm-run-all": "^4.1.2",
         "pug-cli": "^1.0.0-alpha6",
         "tslint": "^5.15.0",
-        "typescript": "~3.3.4000"
+        "typescript": "~3.5.2"
     },
     "engines": {
         "node": ">=8.15.1"

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,7 @@
       ]
     },
     "no-submodule-imports": {
-      "options": ["typedoc/dist/lib/models"]
+      "options": ["@gerrit0/typedoc/dist/lib/models"]
     }
   },
   "jsRules": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,33 @@
     tslint-plugin-prettier "^2.0.1"
     tslint-react "^3.6.0"
 
+"@gerrit0/typedoc-default-themes@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/@gerrit0/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz#40f71cd36be75a0a8550e43b3eae51326767e77d"
+  integrity sha512-FVLlZX1hP3ONLTnvldbiK0ApP+uNjG0vw2qtIQChxodjhbvkL2mC6DVrfUwnCd+ruQa1U1RliyAzjDZPYEjRfw==
+  dependencies:
+    backbone "^1.4.0"
+    jquery "^3.4.1"
+    lunr "^2.3.6"
+    underscore "^1.9.1"
+
+"@gerrit0/typedoc@^0.15.2":
+  version "0.15.2"
+  resolved "https://registry.npmjs.org/@gerrit0/typedoc/-/typedoc-0.15.2.tgz#08121eed2f72cafa7b40d6677aff08541b025a9d"
+  integrity sha512-XnLYUGvjE9gjjXFg9cCrWeLWxOzcdox2ULKitsPVsJXawVdKS8mSUdQ7TbYvO2+ObFq/qFkTtIz6vBCtw4/i+g==
+  dependencies:
+    "@gerrit0/typedoc-default-themes" "^0.6.0"
+    "@types/minimatch" "3.0.3"
+    fs-extra "^7.0.1"
+    handlebars "^4.1.2"
+    highlight.js "^9.13.1"
+    lodash "^4.17.11"
+    marked "^0.6.2"
+    minimatch "^3.0.0"
+    progress "^2.0.3"
+    shelljs "^0.8.3"
+    typescript "3.5.x"
+
 "@lerna/add@3.13.1":
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.13.1.tgz#2cd7838857edb3b43ed73e3c21f69a20beb9b702"
@@ -706,14 +733,7 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.1.0.tgz#93b1be91f63c184450385272c47b6496fd028e02"
   integrity sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==
 
-"@types/fs-extra@^5.0.5":
-  version "5.0.5"
-  resolved "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz#080d90a792f3fa2c5559eb44bd8ef840aae9104b"
-  integrity sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==
-  dependencies:
-    "@types/node" "*"
-
-"@types/glob@*", "@types/glob@^7.1.1":
+"@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -721,11 +741,6 @@
     "@types/events" "*"
     "@types/minimatch" "*"
     "@types/node" "*"
-
-"@types/highlight.js@^9.12.3":
-  version "9.12.3"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
-  integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
 
 "@types/jest-diff@*":
   version "20.0.1"
@@ -749,12 +764,7 @@
   resolved "https://registry.yarnpkg.com/@types/kss/-/kss-3.0.1.tgz#e302e9b844454671c5c679d235a4a9fe10abd4b9"
   integrity sha512-q3JUq12ansjW8gK03C69OXKkJ8LsakYlnn3/0B3D6MPR2T2Saf+iXKZcfWgKTgZmPeV+y7tkS8GjcBI9lESnFQ==
 
-"@types/lodash@^4.14.123":
-  version "4.14.123"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
-  integrity sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==
-
-"@types/marked@^0.6.0", "@types/marked@^0.6.5":
+"@types/marked@^0.6.5":
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.6.5.tgz#3cf2a56ef615dad24aaf99784ef90a9eba4e29d8"
   integrity sha512-6kBKf64aVfx93UJrcyEZ+OBM5nGv4RLsI6sR1Ar34bpgvGVRoyTgpxn4ZmtxOM5aDTAaaznYuYUH8bUX3Nk3YA==
@@ -768,14 +778,6 @@
   version "11.13.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.2.tgz#dc85dde46aa8740bb4aed54b8104250f8f849503"
   integrity sha512-HOtU5KqROKT7qX/itKHuTtt5fV0iXbheQvrgbLNXFJQBY/eh+VS5vmmTAVlo3qIGMsypm0G4N1t2AXjy1ZicaQ==
-
-"@types/shelljs@^0.8.3":
-  version "0.8.5"
-  resolved "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.5.tgz#1e507b2f6d1f893269bd3e851ec24419ef9beeea"
-  integrity sha512-bZgjwIWu9gHCjirKJoOlLzGi5N0QgZ5t7EXEuoqyWCHTuSddURXo3FOBYDyRPNOWzZ6NbkLvZnVkn483Y/tvcQ==
-  dependencies:
-    "@types/glob" "*"
-    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "13.0.0"
@@ -1266,7 +1268,7 @@ babylon@^6.18.0:
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
-backbone@^1.1.2:
+backbone@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
   integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
@@ -2608,16 +2610,7 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-extra@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.0.tgz#8cc3f47ce07ef7b3593a11b9fb245f7e34c041d6"
-  integrity sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -2887,10 +2880,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.0.0, handlebars@^4.0.3, handlebars@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
-  integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
+handlebars@^4.0.0, handlebars@^4.0.3, handlebars@^4.1.0, handlebars@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -3893,10 +3886,10 @@ jest@^23.6.0:
     import-local "^1.0.0"
     jest-cli "^23.6.0"
 
-jquery@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz#2c89d6889b5eac522a7eea32c14521559c6cbf02"
-  integrity sha1-LInWiJterFIqfuoywUUhVZxsvwI=
+jquery@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-stringify@^1.0.1:
   version "1.0.2"
@@ -4379,10 +4372,10 @@ markdown-it@^8.4.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-marked@^0.6.0:
-  version "0.6.2"
-  resolved "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
-  integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
+marked@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz#79babad78af638ba4d522a9e715cdfdd2429e946"
+  integrity sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==
 
 marked@^0.7.0:
   version "0.7.0"
@@ -6728,42 +6721,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.6.0-0:
-  version "0.6.0-0"
-  resolved "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.0-0.tgz#a4867eaf91fb7888efd01680f1328b72e8a33640"
-  integrity sha512-O7hBMS1yBCozvVUntIIdlBk04WiqM+f6NOEc9p+LimJSFKJMF66cgzejeiybuTk6mgbMJW+olg42BNYC8E9x9Q==
-  dependencies:
-    backbone "^1.1.2"
-    jquery "^2.2.4"
-    lunr "^2.3.6"
-    underscore "^1.9.1"
-
-typedoc@^0.15.0-0:
-  version "0.15.0-0"
-  resolved "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0-0.tgz#4d0acd8697c22824fb51fff68766fd435b99163d"
-  integrity sha512-N43CSq6T22MVrP1kb0OYusgwnUniwuh9vGVmtgTCjvTSkuJjdMyMeJPMfnugmfRIWxuP9pO6wvNhdDRG32+EQA==
-  dependencies:
-    "@types/fs-extra" "^5.0.5"
-    "@types/highlight.js" "^9.12.3"
-    "@types/lodash" "^4.14.123"
-    "@types/marked" "^0.6.0"
-    "@types/minimatch" "3.0.3"
-    "@types/shelljs" "^0.8.3"
-    fs-extra "^7.0.1"
-    handlebars "^4.1.0"
-    highlight.js "^9.13.1"
-    lodash "^4.17.11"
-    marked "^0.6.0"
-    minimatch "^3.0.0"
-    progress "^2.0.3"
-    shelljs "^0.8.3"
-    typedoc-default-themes "^0.6.0-0"
-    typescript "3.3.x"
-
-typescript@3.3.x, typescript@~3.3.4000:
-  version "3.3.4000"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
-  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+typescript@3.5.x, typescript@~3.5.2:
+  version "3.5.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Upgrade TypeScript to 3.5.2

Open to discussion on this, but also swapped the `typedoc` dep for `@gerrit0/typedoc`, which is cut from master of the same repo but published under a separate namespace. I was thinking we can at least get documentalist on TypeScript 3.5.x for consumers, and then when `typedoc` finally releases we can swap it back