### PR TITLE
fix: NOENT error on win platform

### DIFF
--- a/packages/compiler/src/plugins/npm.ts
+++ b/packages/compiler/src/plugins/npm.ts
@@ -80,7 +80,7 @@ export class NpmPlugin implements IPlugin<INpmPluginData> {
     private getNpmInfo(packageName: string) {
         return new Promise<string>(resolve => {
             let stdout = "";
-            const child = spawn("npm", ["info", "--json", packageName]);
+            const child = spawn("npm", ["info", "--json", packageName], { shell: true });
             child.stdout.setEncoding("utf8");
             child.stdout.on("data", data => (stdout += data));
             child.on("close", () => resolve(stdout));


### PR DESCRIPTION
This fixes a `spawn NOENT` error when running the compiler on win platforms.

Related to [issue with compiling docs-data in BlueprintJS](https://github.com/palantir/blueprint/issues/3062#issuecomment-439363356).