### PR TITLE
break: drop I prefix from all interface names

### DIFF
--- a/packages/client/src/compiler.ts
+++ b/packages/client/src/compiler.ts
@@ -19,7 +19,7 @@ import { StringOrTag } from "./tags";
 /**
  * Each plugin receives a `Compiler` instance to aid in the processing of source files.
  */
-export interface ICompiler {
+export interface Compiler {
     /**
      * Converts an array of entries into a map of key to entry, using given
      * callback to extract key from each item.
@@ -40,7 +40,7 @@ export interface ICompiler {
      * tag words array may be provided, in which case the line will be left as
      * is.
      */
-    renderBlock(blockContent: string, reservedTagWords?: string[]): IBlock;
+    renderBlock(blockContent: string, reservedTagWords?: string[]): Block;
 
     /**
      * Render a string of markdown to HTML, using the options from `Documentalist`.
@@ -61,7 +61,7 @@ export interface ICompiler {
  * actual contents of file...
  * ```
  */
-export interface IMetadata {
+export interface Metadata {
     /**
      * Unique ID for addressing this page.
      * @default filename without extension
@@ -82,7 +82,7 @@ export interface IMetadata {
  * The output of `renderBlock` which parses a long form documentation block into
  * metadata, rendered markdown, and tags.
  */
-export interface IBlock {
+export interface Block {
     /** Parsed nodes of source file. An array of markdown-rendered HTML strings or `@tag` objects. */
     contents: StringOrTag[];
 
@@ -90,5 +90,5 @@ export interface IBlock {
     contentsRaw: string;
 
     /** Arbitrary YAML metadata parsed from front matter of source file, if any, or `{}`. */
-    metadata: IMetadata;
+    metadata: Metadata;
 }

--- a/packages/client/src/kss.ts
+++ b/packages/client/src/kss.ts
@@ -15,7 +15,7 @@
  */
 
 /** A single modifier for an example. */
-export interface IKssModifier {
+export interface KssModifier {
     documentation: string;
     name: string;
 }
@@ -23,7 +23,7 @@ export interface IKssModifier {
 /**
  * A markup/modifiers example parsed from a KSS comment block.
  */
-export interface IKssExample {
+export interface KssExample {
     /** Raw documentation string. */
     documentation: string;
     /**
@@ -37,7 +37,7 @@ export interface IKssExample {
      */
     markupHtml: string;
     /** Array of modifiers supported by HTML markup. */
-    modifiers: IKssModifier[];
+    modifiers: KssModifier[];
     /** Unique reference for addressing this example. */
     reference: string;
 }
@@ -47,8 +47,8 @@ export interface IKssExample {
  *
  * @see KSSPlugin
  */
-export interface IKssPluginData {
+export interface KssPluginData {
     css: {
-        [reference: string]: IKssExample;
+        [reference: string]: KssExample;
     };
 }

--- a/packages/client/src/markdown.ts
+++ b/packages/client/src/markdown.ts
@@ -14,31 +14,31 @@
  * limitations under the License.
  */
 
-import { IBlock } from "./compiler";
-import { INavigable } from "./tags";
+import { Block } from "./compiler";
+import { Navigable as Navigable } from "./tags";
 
 /**
  * The `MarkdownPlugin` exports a map of markdown `pages` keyed by reference,
  * and a multi-rooted `nav` tree of page nodes.
  */
-export interface IMarkdownPluginData {
+export interface MarkdownPluginData {
     /**
      * An ordered, nested, multi-rooted tree describing the navigation layout
      * of all the pages and their headings. The representation is constructued by
      * tracing `@page` and `@#+` tags.
      */
-    nav: IPageNode[];
+    nav: PageNode[];
 
     /** A map of page reference to data. */
     pages: {
-        [reference: string]: IPageData;
+        [reference: string]: PageData;
     };
 }
 
 /**
  * A single Documentalist page, parsed from a single source file.
  */
-export interface IPageData extends IBlock {
+export interface PageData extends Block {
     /** Unique identifier for addressing this page. */
     reference: string;
 
@@ -53,21 +53,21 @@ export interface IPageData extends IBlock {
 }
 
 /** An `@#+` tag belongs to a specific page. */
-export interface IHeadingNode extends INavigable {
+export interface HeadingNode extends Navigable {
     /** Display title of page heading. */
     title: string;
 }
 
 /** A page has ordered children composed of `@#+` and `@page` tags. */
-export interface IPageNode extends IHeadingNode {
+export interface PageNode extends HeadingNode {
     /** Ordered list of pages and headings that appear on this page. */
-    children: Array<IPageNode | IHeadingNode>;
+    children: Array<PageNode | HeadingNode>;
 
     /** Unique reference of this page, used for retrieval from store. */
     reference: string;
 }
 
-/** Type guard for `IPageNode`, useful for its `children` array. */
-export function isPageNode(node: any): node is IPageNode {
-    return node != null && (node as IPageNode).children != null;
+/** Type guard for `PageNode`, useful for its `children` array. */
+export function isPageNode(node: any): node is PageNode {
+    return node != null && (node as PageNode).children != null;
 }

--- a/packages/client/src/markdown.ts
+++ b/packages/client/src/markdown.ts
@@ -15,7 +15,7 @@
  */
 
 import { Block } from "./compiler";
-import { Navigable as Navigable } from "./tags";
+import { Navigable } from "./tags";
 
 /**
  * The `MarkdownPlugin` exports a map of markdown `pages` keyed by reference,

--- a/packages/client/src/npm.ts
+++ b/packages/client/src/npm.ts
@@ -17,7 +17,7 @@
 /**
  * NPM package metadata
  */
-export interface INpmPackage {
+export interface NpmPackageInfo {
     /** Package name. */
     name: string;
 
@@ -47,12 +47,12 @@ export interface INpmPackage {
 }
 
 /**
- * The `KssPlugin` exports a `css` key that contains a map of styleguide references to markup/modifier examples.
+ * The `NpmPlugin` exports an `npm` key that contains a map of package names to their associated metadata.
  *
- * @see KSSPlugin
+ * @see NpmPlugin
  */
-export interface INpmPluginData {
+export interface NpmPluginData {
     npm: {
-        [packageName: string]: INpmPackage;
+        [packageName: string]: NpmPackageInfo;
     };
 }

--- a/packages/client/src/plugin.ts
+++ b/packages/client/src/plugin.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ICompiler } from "./compiler";
+import { Compiler } from "./compiler";
 
 /**
  * A Documentalist plugin is an object with a `compile(files, compiler)` function
@@ -24,7 +24,7 @@ import { ICompiler } from "./compiler";
  * to accept options.
  *
  * ```ts
- * import { ICompiler, IFile, IPlugin } from "documentalist/client";
+ * import { Compiler, File, Plugin } from "documentalist/client";
  *
  * export interface MyData {
  *     pluginName: { ... }
@@ -34,24 +34,24 @@ import { ICompiler } from "./compiler";
  *     ...
  * }
  *
- * export class MyPlugin implements IPlugin<MyData> {
+ * export class MyPlugin implements Plugin<MyData> {
  *     public constructor(options: MyOptions = {}) {}
  *
- *     public compile(files: IFile[], compiler: ICompiler) {
+ *     public compile(files: File[], compiler: Compiler) {
  *         return files.map(transformToMyData);
  *     }
  * }
  * ```
  */
-export interface IPlugin<T> {
-    compile(files: IFile[], compiler: ICompiler): T | Promise<T>;
+export interface Plugin<T> {
+    compile(files: File[], compiler: Compiler): T | Promise<T>;
 }
 
 /**
  * Abstract representation of a file, containing absolute path and synchronous `read` operation.
  * This allows plugins to use only the path of a file without reading it.
  */
-export interface IFile {
+export interface File {
     path: string;
     read(): string;
 }

--- a/packages/client/src/tags.ts
+++ b/packages/client/src/tags.ts
@@ -15,7 +15,7 @@
  */
 
 /** Represents a single `@tag <value>` line from a file. */
-export interface ITag {
+export interface Tag {
     /** Tag name. */
     tag: string;
 
@@ -27,7 +27,7 @@ export interface ITag {
  * The basic components of a navigable resource: a "route" at which it can be accessed and
  * its depth in the layout hierarchy. Heading tags and hierarchy nodes both extend this interface.
  */
-export interface INavigable {
+export interface Navigable {
     /** Fully-qualified route of the heading, which can be used as anchor `href`. */
     route: string;
 
@@ -43,22 +43,22 @@ export interface INavigable {
  * Heading tags include additional information over regular tags: fully-qualified `route` of the
  * heading (which can be used as anchor `href`), and `level` to determine which `<h#>` tag to use.
  */
-export interface IHeadingTag extends ITag, INavigable {
+export interface HeadingTag extends Tag, Navigable {
     tag: "heading";
 }
 
 /** An entry in `contents` array: either an HTML string or an `@tag`. */
-export type StringOrTag = string | ITag;
+export type StringOrTag = string | Tag;
 
 /**
  * Type guard to determine if a `contents` node is an `@tag` statement.
  * Optionally tests tag name too, if `tagName` arg is provided.
  */
-export function isTag(node: any, tagName?: string): node is ITag {
-    return node != null && (node as ITag).tag != null && (tagName == null || (node as ITag).tag === tagName);
+export function isTag(node: any, tagName?: string): node is Tag {
+    return node != null && (node as Tag).tag != null && (tagName == null || (node as Tag).tag === tagName);
 }
 
 /** Type guard to deterimine if a `contents` node is an `@#+` heading tag. */
-export function isHeadingTag(node: any): node is IHeadingTag {
+export function isHeadingTag(node: any): node is HeadingTag {
     return isTag(node, "heading");
 }

--- a/packages/client/src/typescript.ts
+++ b/packages/client/src/typescript.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IBlock } from "./compiler";
+import { Block } from "./compiler";
 
 /** Enumeration describing the various kinds of member supported by this plugin. */
 export enum Kind {
@@ -32,7 +32,7 @@ export enum Kind {
 }
 
 /** Compiler flags about this member. */
-export interface ITsFlags {
+export interface TsFlags {
     /** This flag supports an optional message, typically used to include a version number. */
     isDeprecated?: boolean | string;
     isExported?: boolean;
@@ -46,17 +46,17 @@ export interface ITsFlags {
 }
 
 /** Base type for all typescript documentation members. */
-export interface ITsDocBase<K extends Kind = Kind> {
+export interface TsDocBase<K extends Kind = Kind> {
     /** Type brand indicating kind of member; type guards will reveal further information about it. */
     kind: K;
 
     /** Compiled documentation: `contents` field contains an array of markdown strings or `@tag value` objects. */
-    documentation?: IBlock;
+    documentation?: Block;
 
     /** Original file name in which this member originated, relative to current working directory. */
     fileName?: string;
 
-    flags?: ITsFlags;
+    flags?: TsFlags;
 
     /** Name of this member in code, also used as its identifiers in the data store. */
     name: string;
@@ -72,56 +72,56 @@ export interface ITsDocBase<K extends Kind = Kind> {
 
 /**
  * Common type for a callable member, something that can be invoked.
- * @see ITsConstructor
- * @see ITsMethod
+ * @see TsConstructor
+ * @see TsMethod
  */
-export interface ITsCallable {
+export interface TsCallable {
     /** Type name from which this method was inherited. Typically takes the form `Interface.member`. */
     inheritedFrom?: string;
     /** A method has at least one signature, which describes the parameters and return type and contains documentation. */
-    signatures: ITsSignature[];
+    signatures: TsSignature[];
 }
 
 /** Re-usable interface for Typescript members that support a notion of "default value." */
-export interface ITsDefaultValue {
+export interface TsDefaultValue {
     /** The default value of this property, from an initializer or an `@default` tag. */
     defaultValue?: string;
 }
 
 /** Re-usable interface for Typescript members that look like objects. */
-export interface ITsObjectDefinition {
+export interface TsObjectDefinition {
     /** List of type strings that this definition `extends`. */
     extends?: string[];
     /** List of type names that this definition `implements`. */
     implements?: string[];
     /** Index signature for this object, if declared. */
-    indexSignature?: ITsSignature;
+    indexSignature?: TsSignature;
     /** Property members of this definition. */
-    properties: ITsProperty[];
+    properties: TsProperty[];
     /** Method members of this definiton. */
-    methods: ITsMethod[];
+    methods: TsMethod[];
 }
 
 /**
  * Documentation for a class constructor. See `signatures` array for actual callable signatures and rendered docs.
- * @see ITsClass
+ * @see TsClass
  */
-export interface ITsConstructor extends ITsDocBase, ITsCallable {
+export interface TsConstructor extends TsDocBase, TsCallable {
     kind: Kind.Constructor;
 }
 
-export interface ITsAccessor extends ITsDocBase {
+export interface TsAccessor extends TsDocBase {
     kind: Kind.Accessor;
     /** If a set signature is defined and documented for this accessor, this will contain its documentation. */
-    getDocumentation: IBlock | undefined;
+    getDocumentation: Block | undefined;
     /** If a get signature is defined and documented for this accessor, this will contain its documentation. */
-    setDocumentation: IBlock | undefined;
+    setDocumentation: Block | undefined;
     /** Type of the accessor. */
     type: string;
 }
 
 /** Documentation for a method. See `signatures` array for actual callable signatures and rendered docs. */
-export interface ITsMethod extends ITsDocBase, ITsCallable {
+export interface TsMethod extends TsDocBase, TsCallable {
     kind: Kind.Method;
 }
 
@@ -129,12 +129,12 @@ export interface ITsMethod extends ITsDocBase, ITsCallable {
  * Documentation for a single signature, including parameters, return type, and full type string.
  * Signatures are used for methods and constructors on classes or interfaces, and for index signatures on objects.
  */
-export interface ITsSignature extends ITsDocBase {
+export interface TsSignature extends TsDocBase {
     kind: Kind.Signature;
     /** Signatures do not have flags of their own. Flags can be found on the parent and on each parameter. */
     flags: undefined;
     /** Signature parameters, each with their own docs and data. */
-    parameters: ITsParameter[];
+    parameters: TsParameter[];
     /** Return type of the signature. */
     returnType: string;
     /** Fully qualified type string describing this method, including parameters and return type. */
@@ -142,7 +142,7 @@ export interface ITsSignature extends ITsDocBase {
 }
 
 /** Documentation for a single parameter to a signature. */
-export interface ITsParameter extends ITsDocBase, ITsDefaultValue {
+export interface TsParameter extends TsDocBase, TsDefaultValue {
     kind: Kind.Parameter;
     /** Fully qualified type string describing this parameter. */
     type: string;
@@ -151,7 +151,7 @@ export interface ITsParameter extends ITsDocBase, ITsDefaultValue {
 }
 
 /** Documentation for a property of an object, which may have a default value. */
-export interface ITsProperty extends ITsDocBase, ITsDefaultValue {
+export interface TsProperty extends TsDocBase, TsDefaultValue {
     kind: Kind.Property;
     /** Type name from which this property was inherited. Typically takes the form `Interface.member`. */
     inheritedFrom?: string;
@@ -160,37 +160,37 @@ export interface ITsProperty extends ITsDocBase, ITsDefaultValue {
 }
 
 /** Documentation for an `interface` definition. */
-export interface ITsInterface extends ITsDocBase, ITsObjectDefinition {
+export interface TsInterface extends TsDocBase, TsObjectDefinition {
     kind: Kind.Interface;
 }
 
 /** Documentation for a `class` definition. */
-export interface ITsClass extends ITsDocBase, ITsObjectDefinition {
+export interface TsClass extends TsDocBase, TsObjectDefinition {
     kind: Kind.Class;
     /** Constructor signature of this class. Note the special name here, as `constructor` is a JavaScript keyword. */
-    constructorType: ITsConstructor;
-    accessors: ITsAccessor[];
+    constructorType: TsConstructor;
+    accessors: TsAccessor[];
 }
 /** A member of an `enum` definition. An enum member will have a `defaultValue` if it was declared with an initializer. */
-export interface ITsEnumMember extends ITsDocBase, ITsDefaultValue {
+export interface TsEnumMember extends TsDocBase, TsDefaultValue {
     kind: Kind.EnumMember;
 }
 
 /** Documentation for an `enum` definition. */
-export interface ITsEnum extends ITsDocBase {
+export interface TsEnum extends TsDocBase {
     kind: Kind.Enum;
     /** Enumeration members. */
-    members: ITsEnumMember[];
+    members: TsEnumMember[];
 }
 
 /** A type alias, defined using `export type {name} = {type}.` The `type` property will contain the full type alias as a string. */
-export interface ITsTypeAlias extends ITsDocBase {
+export interface TsTypeAlias extends TsDocBase {
     kind: Kind.TypeAlias;
     /** Type string for which this member is an alias. */
     type: string;
 }
 
-export type TypescriptDocEntry = ITsClass | ITsInterface | ITsEnum | ITsMethod | ITsTypeAlias;
+export type TsDocEntry = TsClass | TsInterface | TsEnum | TsMethod | TsTypeAlias;
 
 /**
  * The `TypescriptPlugin` exports a `typescript` key that contains a map of member name to
@@ -199,23 +199,23 @@ export type TypescriptDocEntry = ITsClass | ITsInterface | ITsEnum | ITsMethod |
  * Only classes and interfaces are provided at this root level, but each member contains full
  * information about its children, such as methods (and signatures and parameters) and properties.
  */
-export interface ITypescriptPluginData {
+export interface TypescriptPluginData {
     typescript: {
-        [name: string]: TypescriptDocEntry;
+        [name: string]: TsDocEntry;
     };
 }
 
-function typeguard<T extends ITsDocBase>(kind: Kind) {
+function typeguard<T extends TsDocBase>(kind: Kind) {
     return (data: any): data is T => data != null && (data as T).kind === kind;
 }
 
-export const isTsClass = typeguard<ITsClass>(Kind.Class);
-export const isTsConstructor = typeguard<ITsConstructor>(Kind.Constructor);
-export const isTsEnum = typeguard<ITsEnum>(Kind.Enum);
-export const isTsEnumMember = typeguard<ITsEnumMember>(Kind.EnumMember);
-export const isTsInterface = typeguard<ITsInterface>(Kind.Interface);
-export const isTsMethod = typeguard<ITsMethod>(Kind.Method);
-export const isTsParameter = typeguard<ITsParameter>(Kind.Parameter);
-export const isTsProperty = typeguard<ITsProperty>(Kind.Property);
-export const isTsSignature = typeguard<ITsSignature>(Kind.Signature);
-export const isTsTypeAlias = typeguard<ITsTypeAlias>(Kind.TypeAlias);
+export const isTsClass = typeguard<TsClass>(Kind.Class);
+export const isTsConstructor = typeguard<TsConstructor>(Kind.Constructor);
+export const isTsEnum = typeguard<TsEnum>(Kind.Enum);
+export const isTsEnumMember = typeguard<TsEnumMember>(Kind.EnumMember);
+export const isTsInterface = typeguard<TsInterface>(Kind.Interface);
+export const isTsMethod = typeguard<TsMethod>(Kind.Method);
+export const isTsParameter = typeguard<TsParameter>(Kind.Parameter);
+export const isTsProperty = typeguard<TsProperty>(Kind.Property);
+export const isTsSignature = typeguard<TsSignature>(Kind.Signature);
+export const isTsTypeAlias = typeguard<TsTypeAlias>(Kind.TypeAlias);

--- a/packages/compiler/src/__tests__/__fixtures__/interfaces.ts
+++ b/packages/compiler/src/__tests__/__fixtures__/interfaces.ts
@@ -17,7 +17,7 @@
 /** All icon identifiers */
 export type IconName = "add" | "remove" | "plus" | "minus";
 
-export interface IActionProps {
+export interface ActionProps {
     /** Whether this action is non-interactive. */
     disabled?: boolean;
 
@@ -31,7 +31,7 @@ export interface IActionProps {
     text: string;
 }
 
-export interface IButtonProps extends IActionProps {
+export interface ButtonProps extends ActionProps {
     /**
      * If set to `true`, the button will display in an active state.
      * This is equivalent to setting `className="pt-active"`.
@@ -70,7 +70,7 @@ export interface IButtonProps extends IActionProps {
 /**
  * Each plugin receives a `Compiler` instance to aid in the processing of source files.
  */
-export interface ICompiler {
+export interface Compiler {
     /**
      * Converts an array of entries into a map of key to entry, using given
      * callback to extract key from each item.

--- a/packages/compiler/src/__tests__/__snapshots__/typescript.test.ts.snap
+++ b/packages/compiler/src/__tests__/__snapshots__/typescript.test.ts.snap
@@ -723,7 +723,7 @@ exports[`TypescriptPlugin functions snapshot 1`] = `
 
 exports[`TypescriptPlugin interfaces snapshot 1`] = `
 {
-  "IActionProps": {
+  "ActionProps": {
     "documentation": undefined,
     "extends": undefined,
     "fileName": "src/__tests__/__fixtures__/interfaces.ts",
@@ -741,7 +741,7 @@ exports[`TypescriptPlugin interfaces snapshot 1`] = `
     "indexSignature": undefined,
     "kind": "interface",
     "methods": [],
-    "name": "IActionProps",
+    "name": "ActionProps",
     "properties": [
       {
         "defaultValue": undefined,
@@ -858,10 +858,10 @@ exports[`TypescriptPlugin interfaces snapshot 1`] = `
     ],
     "sourceUrl": "https://github.com/palantir/documentalist/blob/develop/packages/compiler/src/__tests__/__fixtures__/interfaces.ts#L20",
   },
-  "IButtonProps": {
+  "ButtonProps": {
     "documentation": undefined,
     "extends": [
-      "IActionProps<>",
+      "ActionProps<>",
     ],
     "fileName": "src/__tests__/__fixtures__/interfaces.ts",
     "flags": {
@@ -908,7 +908,7 @@ exports[`TypescriptPlugin interfaces snapshot 1`] = `
     },
     "kind": "interface",
     "methods": [],
-    "name": "IButtonProps",
+    "name": "ButtonProps",
     "properties": [
       {
         "defaultValue": "\`\`\`ts
@@ -970,7 +970,7 @@ This is equivalent to setting
           "isRest": false,
           "isStatic": false,
         },
-        "inheritedFrom": "IActionProps.disabled",
+        "inheritedFrom": "ActionProps.disabled",
         "kind": "property",
         "name": "disabled",
         "sourceUrl": "https://github.com/palantir/documentalist/blob/develop/packages/compiler/src/__tests__/__fixtures__/interfaces.ts#L22",
@@ -1028,7 +1028,7 @@ This is equivalent to setting
           "isRest": false,
           "isStatic": false,
         },
-        "inheritedFrom": "IActionProps.iconName",
+        "inheritedFrom": "ActionProps.iconName",
         "kind": "property",
         "name": "iconName",
         "sourceUrl": "https://github.com/palantir/documentalist/blob/develop/packages/compiler/src/__tests__/__fixtures__/interfaces.ts#L25",
@@ -1090,7 +1090,7 @@ The width of the button is not affected by the value of this prop.",
           "isRest": false,
           "isStatic": false,
         },
-        "inheritedFrom": "IActionProps.onClick",
+        "inheritedFrom": "ActionProps.onClick",
         "kind": "property",
         "name": "onClick",
         "sourceUrl": "https://github.com/palantir/documentalist/blob/develop/packages/compiler/src/__tests__/__fixtures__/interfaces.ts#L28",
@@ -1148,7 +1148,7 @@ The width of the button is not affected by the value of this prop.",
           "isRest": false,
           "isStatic": false,
         },
-        "inheritedFrom": "IActionProps.text",
+        "inheritedFrom": "ActionProps.text",
         "kind": "property",
         "name": "text",
         "sourceUrl": "https://github.com/palantir/documentalist/blob/develop/packages/compiler/src/__tests__/__fixtures__/interfaces.ts#L31",
@@ -1208,7 +1208,7 @@ Note that this prop has no effect on
     ],
     "sourceUrl": "https://github.com/palantir/documentalist/blob/develop/packages/compiler/src/__tests__/__fixtures__/interfaces.ts#L34",
   },
-  "ICompiler": {
+  "Compiler": {
     "documentation": {
       "contents": [
         "<p>Each plugin receives a 
@@ -1470,7 +1470,7 @@ is.",
         "sourceUrl": "https://github.com/palantir/documentalist/blob/develop/packages/compiler/src/__tests__/__fixtures__/interfaces.ts#L94",
       },
     ],
-    "name": "ICompiler",
+    "name": "Compiler",
     "properties": [],
     "sourceUrl": "https://github.com/palantir/documentalist/blob/develop/packages/compiler/src/__tests__/__fixtures__/interfaces.ts#L73",
   },

--- a/packages/compiler/src/__tests__/compilerImpl.test.ts
+++ b/packages/compiler/src/__tests__/compilerImpl.test.ts
@@ -15,10 +15,10 @@
  */
 
 import { isHeadingTag } from "@documentalist/client";
-import { Compiler } from "../compiler";
+import { CompilerImpl } from "../compilerImpl";
 
-describe("Compiler", () => {
-    const API = new Compiler({});
+describe("CompilerImpl", () => {
+    const API = new CompilerImpl({});
 
     describe("objectify", () => {
         it("empty array returns empty object", () => {
@@ -71,7 +71,7 @@ describe("Compiler", () => {
             expect(contents).toHaveLength(3);
             expect(contents[1]).toEqual({
                 tag: "interface",
-                value: "IButtonProps",
+                value: "ButtonProps",
             });
         });
 
@@ -94,7 +94,7 @@ describe("Compiler", () => {
             // only one string (reserved @word does not get split to its own entry)
             expect(contents).toHaveLength(1);
             // @tag value comes out exactly as written in source, on its own line
-            expect((contents[0] as string).split("\n")).toContain("@interface IButtonProps");
+            expect((contents[0] as string).split("\n")).toContain("@interface ButtonProps");
         });
     });
 });
@@ -102,7 +102,7 @@ describe("Compiler", () => {
 const FILE = `
 # Title
 description
-@interface IButtonProps
+@interface ButtonProps
 more description
 `;
 
@@ -110,7 +110,7 @@ const HEADING_FILE = `
 @# Title
 description
 @## Section 1
-@interface IButtonProps
+@interface ButtonProps
 more words
 @### Section 1a
 more words

--- a/packages/compiler/src/__tests__/typescript.test.ts
+++ b/packages/compiler/src/__tests__/typescript.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { isTsClass, isTsInterface, ITypescriptPluginData } from "@documentalist/client";
+import { isTsClass, isTsInterface, TypescriptPluginData } from "@documentalist/client";
 import { Documentalist } from "../documentalist";
-import { ITypescriptPluginOptions, TypescriptPlugin } from "../plugins/typescript/typescriptPlugin";
+import { TypescriptPluginOptions, TypescriptPlugin } from "../plugins/typescript/typescriptPlugin";
 
 describe("TypescriptPlugin", () => {
     it("classes snapshot", () => expectSnapshot("classes"));
@@ -31,11 +31,11 @@ describe("TypescriptPlugin", () => {
         });
 
         it("excludeNames", () => {
-            // get IButtonProps properties; should be missing a few.
+            // get ButtonProps properties; should be missing a few.
             expectSnapshot(
                 "interfaces",
                 { excludeNames: [/icon/i, "intent"] },
-                ({ IButtonProps }) => isTsInterface(IButtonProps) && IButtonProps.properties.map((p) => p.name),
+                ({ ButtonProps }) => isTsInterface(ButtonProps) && ButtonProps.properties.map((p) => p.name),
             );
         });
 
@@ -53,9 +53,9 @@ describe("TypescriptPlugin", () => {
 async function expectSnapshot(
     /** name of fixture file to feed into DM */
     name: string,
-    options?: ITypescriptPluginOptions,
+    options?: TypescriptPluginOptions,
     /** a function to transform the DM data, to avoid snapshotting _everything_. defaults to identity function. */
-    transform: (data: ITypescriptPluginData["typescript"]) => any = (arg) => arg,
+    transform: (data: TypescriptPluginData["typescript"]) => any = (arg) => arg,
 ) {
     const fixtureFilepath = `src/__tests__/__fixtures__/${name}.ts`;
     const dm = Documentalist.create().use(

--- a/packages/compiler/src/__tests__/typescript.test.ts
+++ b/packages/compiler/src/__tests__/typescript.test.ts
@@ -16,7 +16,7 @@
 
 import { isTsClass, isTsInterface, TypescriptPluginData } from "@documentalist/client";
 import { Documentalist } from "../documentalist";
-import { TypescriptPluginOptions, TypescriptPlugin } from "../plugins/typescript/typescriptPlugin";
+import { TypescriptPlugin, TypescriptPluginOptions } from "../plugins/typescript/typescriptPlugin";
 
 describe("TypescriptPlugin", () => {
     it("classes snapshot", () => expectSnapshot("classes"));

--- a/packages/compiler/src/compiler.md
+++ b/packages/compiler/src/compiler.md
@@ -39,4 +39,4 @@ pattern to match against source files. The collected matched files will
 be passed to your plugin's `compile` function, along with a `compiler`
 instance that can be used to render blocks of markdown text.
 
-@interface IPlugin
+@interface Plugin

--- a/packages/compiler/src/compilerImpl.ts
+++ b/packages/compiler/src/compilerImpl.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IBlock, ICompiler, IHeadingTag, StringOrTag } from "@documentalist/client";
+import { Block, Compiler, HeadingTag, StringOrTag } from "@documentalist/client";
 import * as yaml from "js-yaml";
 import { marked } from "marked";
 import { relative } from "path";
@@ -31,7 +31,7 @@ const METADATA_REGEX = /^---\n?((?:.|\n)*)\n---\n/;
 const TAG_REGEX = /^@(\S+)(?:\s+([^\n]+))?$/;
 const TAG_SPLIT_REGEX = /^(@\S+(?:\s+[^\n]+)?)$/gm;
 
-export interface ICompilerOptions {
+export interface CompilerOptions {
     /** Options for markdown rendering. See https://github.com/chjj/marked#options-1. */
     markdown?: marked.MarkedOptions;
 
@@ -52,8 +52,8 @@ export interface ICompilerOptions {
     sourceBaseDir?: string;
 }
 
-export class Compiler implements ICompiler {
-    public constructor(private options: ICompilerOptions) {}
+export class CompilerImpl implements Compiler {
+    public constructor(private options: CompilerOptions) {}
 
     public objectify<T>(array: T[], getKey: (item: T) => string) {
         return array.reduce<{ [key: string]: T }>((obj, item) => {
@@ -67,7 +67,7 @@ export class Compiler implements ICompiler {
         return relative(sourceBaseDir, path);
     };
 
-    public renderBlock = (blockContent: string, reservedTagWords = this.options.reservedTags): IBlock => {
+    public renderBlock = (blockContent: string, reservedTagWords = this.options.reservedTags): Block => {
         const { contentsRaw, metadata } = this.extractMetadata(blockContent.trim());
         const contents = this.renderContents(contentsRaw, reservedTagWords);
         return { contents, contentsRaw, metadata };
@@ -128,7 +128,7 @@ export class Compiler implements ICompiler {
                 const value = match[2];
                 if (/#+/.test(tag)) {
                     // NOTE: not enough information to populate `route` field yet
-                    const heading: IHeadingTag = {
+                    const heading: HeadingTag = {
                         level: tag.length,
                         route: "",
                         tag: "heading",

--- a/packages/compiler/src/documentalist.ts
+++ b/packages/compiler/src/documentalist.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import { IFile, IPlugin } from "@documentalist/client";
+import { File, Plugin } from "@documentalist/client";
 import * as fs from "fs";
 import * as glob from "glob";
 import * as path from "path";
-import { Compiler, ICompilerOptions } from "./compiler";
+import { CompilerImpl, CompilerOptions } from "./compilerImpl";
 
 /**
  * Plugins are stored with the regex used to match against file paths.
  */
-export interface IPluginEntry<T> {
+export interface PluginEntry<T> {
     pattern: RegExp;
-    plugin: IPlugin<T>;
+    plugin: Plugin<T>;
 }
 
 export class Documentalist<T> {
@@ -34,11 +34,11 @@ export class Documentalist<T> {
      * This method lends itself particularly well to the chaining syntax:
      * `Documentalist.create(options).use(...)`.
      */
-    public static create(options?: ICompilerOptions): Documentalist<{}> {
+    public static create(options?: CompilerOptions): Documentalist<{}> {
         return new Documentalist(options, []);
     }
 
-    constructor(private options: ICompilerOptions = {}, private plugins: Array<IPluginEntry<T>> = []) {}
+    constructor(private options: CompilerOptions = {}, private plugins: Array<PluginEntry<T>> = []) {}
 
     /**
      * Adds the plugin to Documentalist. Returns a new instance of Documentalist
@@ -53,12 +53,12 @@ export class Documentalist<T> {
      * @param plugin - The plugin implementation
      * @returns A new instance of `Documentalist` with an extended type
      */
-    public use<P>(pattern: RegExp | string, plugin: IPlugin<P>): Documentalist<T & P> {
+    public use<P>(pattern: RegExp | string, plugin: Plugin<P>): Documentalist<T & P> {
         if (typeof pattern === "string") {
             pattern = new RegExp(`${pattern}$`);
         }
 
-        const newPlugins = [...this.plugins, { pattern, plugin }] as Array<IPluginEntry<T & P>>;
+        const newPlugins = [...this.plugins, { pattern, plugin }] as Array<PluginEntry<T & P>>;
         return new Documentalist(this.options, newPlugins);
     }
 
@@ -85,8 +85,8 @@ export class Documentalist<T> {
      *
      * The return type `T` is a union of each plugin's data type.
      */
-    public async documentFiles(files: IFile[]) {
-        const compiler = new Compiler(this.options);
+    public async documentFiles(files: File[]) {
+        const compiler = new CompilerImpl(this.options);
         // need an empty object of correct type that we can merge into
         // tslint:disable-next-line:no-object-literal-type-assertion
         const documentation = {} as T;
@@ -101,7 +101,7 @@ export class Documentalist<T> {
     /**
      * Expands an array of globs and flatten to a single array of files.
      */
-    private expandGlobs(filesGlobs: string[]): IFile[] {
+    private expandGlobs(filesGlobs: string[]): File[] {
         return filesGlobs
             .map((filesGlob) => glob.sync(filesGlob))
             .reduce((a, b) => a.concat(b))

--- a/packages/compiler/src/page.ts
+++ b/packages/compiler/src/page.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { IHeadingNode, IPageData, IPageNode, isHeadingTag, isTag } from "@documentalist/client";
+import { HeadingNode, PageData, PageNode, isHeadingTag, isTag } from "@documentalist/client";
 
 export class PageMap {
-    private store: Map<string, IPageData> = new Map();
+    private store: Map<string, PageData> = new Map();
 
     /** Returns an iterator for all the pages (values) in the map. */
     public pages() {
@@ -42,7 +42,7 @@ export class PageMap {
      * Sets the page data at the given ID, when you already have a full page object.
      * Warns if a page with this ID already exists.
      */
-    public set(id: string, page: IPageData) {
+    public set(id: string, page: PageData) {
         if (this.store.has(id)) {
             console.warn(`Found duplicate page "${id}"; overwriting previous data.`);
             console.warn("Rename headings or use metadata `reference` key to disambiguate.");
@@ -52,14 +52,14 @@ export class PageMap {
 
     /** Returns a JS object mapping page IDs to data. */
     public toObject() {
-        const object: { [key: string]: IPageData } = {};
+        const object: { [key: string]: PageData } = {};
         for (const [key, val] of Array.from(this.store.entries())) {
             object[key] = val;
         }
         return object;
     }
 
-    public toTree(id: string, depth = 0): IPageNode {
+    public toTree(id: string, depth = 0): PageNode {
         const page = this.get(id);
         if (page === undefined) {
             throw new Error(`Unknown @page '${id}' in toTree()`);
@@ -78,12 +78,12 @@ export class PageMap {
     }
 }
 
-function initPageNode({ reference, title }: IPageData, level: number = 0): IPageNode {
+function initPageNode({ reference, title }: PageData, level: number = 0): PageNode {
     // NOTE: `route` may be overwritten in MarkdownPlugin based on nesting.
     return { children: [], level, reference, route: reference, title };
 }
 
-function initHeadingNode(title: string, level: number): IHeadingNode {
+function initHeadingNode(title: string, level: number): HeadingNode {
     // NOTE: `route` will be populated in MarkdownPlugin.
     return { title, level, route: "" };
 }

--- a/packages/compiler/src/page.ts
+++ b/packages/compiler/src/page.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { HeadingNode, PageData, PageNode, isHeadingTag, isTag } from "@documentalist/client";
+import { HeadingNode, isHeadingTag, isTag, PageData, PageNode } from "@documentalist/client";
 
 export class PageMap {
     private store: Map<string, PageData> = new Map();

--- a/packages/compiler/src/plugins/kss.ts
+++ b/packages/compiler/src/plugins/kss.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ICompiler, IFile, IKssExample, IKssModifier, IKssPluginData, IPlugin } from "@documentalist/client";
+import { Compiler, File, KssExample, KssModifier, KssPluginData, Plugin } from "@documentalist/client";
 import * as kss from "kss";
 import * as path from "path";
 
@@ -23,19 +23,19 @@ import * as path from "path";
  * It emits an object keyed by the "styleguide [ref]" section of the comment. The documentation, markup, and modifiers
  * sections will all be emitted in the data.
  *
- * @see IKssExample
+ * @see KssExample
  */
-export class KssPlugin implements IPlugin<IKssPluginData> {
+export class KssPlugin implements Plugin<KssPluginData> {
     public constructor(private options: kss.Options = {}) {}
 
-    public compile(cssFiles: IFile[], dm: ICompiler): IKssPluginData {
+    public compile(cssFiles: File[], dm: Compiler): KssPluginData {
         const styleguide = this.parseFiles(cssFiles);
         const sections = styleguide.sections().map((s) => convertSection(s, dm));
         const css = dm.objectify(sections, (s) => s.reference);
         return { css };
     }
 
-    private parseFiles(files: IFile[]) {
+    private parseFiles(files: File[]) {
         const input = files.map<kss.File>((file) => ({
             base: path.dirname(file.path),
             contents: file.read(),
@@ -46,7 +46,7 @@ export class KssPlugin implements IPlugin<IKssPluginData> {
     }
 }
 
-function convertSection(section: kss.KssSection, dm: ICompiler): IKssExample {
+function convertSection(section: kss.KssSection, dm: Compiler): KssExample {
     return {
         documentation: dm.renderMarkdown(section.description()),
         markup: section.markup() || "",
@@ -56,7 +56,7 @@ function convertSection(section: kss.KssSection, dm: ICompiler): IKssExample {
     };
 }
 
-function convertModifier(mod: kss.KssModifier, dm: ICompiler): IKssModifier {
+function convertModifier(mod: kss.KssModifier, dm: Compiler): KssModifier {
     return {
         documentation: dm.renderMarkdown(mod.description()),
         name: mod.name(),

--- a/packages/compiler/src/plugins/markdown.ts
+++ b/packages/compiler/src/plugins/markdown.ts
@@ -19,12 +19,12 @@ import {
     Compiler,
     File,
     HeadingNode,
+    isHeadingTag,
+    isPageNode,
     MarkdownPluginData,
     PageData,
     PageNode,
     Plugin,
-    isHeadingTag,
-    isPageNode,
     slugify,
 } from "@documentalist/client";
 import * as path from "path";

--- a/packages/compiler/src/plugins/markdown.ts
+++ b/packages/compiler/src/plugins/markdown.ts
@@ -15,14 +15,14 @@
  */
 
 import {
-    IBlock,
-    ICompiler,
-    IFile,
-    IHeadingNode,
-    IMarkdownPluginData,
-    IPageData,
-    IPageNode,
-    IPlugin,
+    Block,
+    Compiler,
+    File,
+    HeadingNode,
+    MarkdownPluginData,
+    PageData,
+    PageNode,
+    Plugin,
     isHeadingTag,
     isPageNode,
     slugify,
@@ -30,7 +30,7 @@ import {
 import * as path from "path";
 import { PageMap } from "../page";
 
-export interface IMarkdownPluginOptions {
+export interface MarkdownPluginOptions {
     /**
      * Page reference that lists the nav roots.
      * @default "_nav"
@@ -43,13 +43,13 @@ export interface IMarkdownPluginOptions {
  * This plugin traces `@page` and `@#+` "heading" tags to discover pages (given a single starting `navPage`)
  * and build up a tree representation of those pages.
  *
- * @see IPageData (rendered markdown page)
- * @see IPageNode (node in navigation tree)
+ * @see PageData (rendered markdown page)
+ * @see PageNode (node in navigation tree)
  */
-export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
-    private options: IMarkdownPluginOptions;
+export class MarkdownPlugin implements Plugin<MarkdownPluginData> {
+    private options: MarkdownPluginOptions;
 
-    public constructor(options: Partial<IMarkdownPluginOptions> = {}) {
+    public constructor(options: Partial<MarkdownPluginOptions> = {}) {
         this.options = {
             navPage: "_nav",
             ...options,
@@ -60,7 +60,7 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
      * Reads the given set of markdown files and adds their data to the internal storage.
      * Returns a plain object mapping page references to their data.
      */
-    public compile(markdownFiles: IFile[], compiler: ICompiler): IMarkdownPluginData {
+    public compile(markdownFiles: File[], compiler: Compiler): MarkdownPluginData {
         const pageMap = this.buildPageStore(markdownFiles, compiler);
         // now that we have all known pages, we can resolve @include tags.
         this.resolveIncludeTags(pageMap);
@@ -77,7 +77,7 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
         return { nav, pages };
     }
 
-    private blockToPage(sourcePath: string, block: IBlock): IPageData {
+    private blockToPage(sourcePath: string, block: Block): PageData {
         const reference = getReference(sourcePath, block);
         return {
             reference,
@@ -88,8 +88,8 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
         };
     }
 
-    /** Convert each file to IPageData and populate store. */
-    private buildPageStore(markdownFiles: IFile[], { relativePath, renderBlock }: ICompiler) {
+    /** Convert each file to PageData and populate store. */
+    private buildPageStore(markdownFiles: File[], { relativePath, renderBlock }: Compiler) {
         const pageMap = new PageMap();
         for (const file of markdownFiles) {
             const block = renderBlock(file.read());
@@ -104,7 +104,7 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
      * If node is a page, then it also computes `route` for each heading and recurses through child
      * pages.
      */
-    private recurseRoute(pageMap: PageMap, node: IPageNode | IHeadingNode, parent?: IPageNode) {
+    private recurseRoute(pageMap: PageMap, node: PageNode | HeadingNode, parent?: PageNode) {
         // compute route for page and heading NODES (from nav tree)
         const baseRoute = parent === undefined ? [] : [parent.route];
         const route = isPageNode(node)
@@ -128,7 +128,7 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
         }
     }
 
-    private resolveRoutes(pageMap: PageMap, nav: IPageNode[]) {
+    private resolveRoutes(pageMap: PageMap, nav: PageNode[]) {
         for (const page of nav) {
             // walk the nav tree and compute `route` property for each resource.
             this.recurseRoute(pageMap, page);
@@ -154,14 +154,14 @@ export class MarkdownPlugin implements IPlugin<IMarkdownPluginData> {
     }
 }
 
-function getReference(absolutePath: string, { metadata }: IBlock) {
+function getReference(absolutePath: string, { metadata }: Block) {
     if (metadata.reference != null) {
         return metadata.reference;
     }
     return path.basename(absolutePath, path.extname(absolutePath));
 }
 
-function getTitle(block: IBlock) {
+function getTitle(block: Block) {
     if (block.metadata.title != null) {
         return block.metadata.title;
     }

--- a/packages/compiler/src/plugins/npm.ts
+++ b/packages/compiler/src/plugins/npm.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { ICompiler, IFile, INpmPackage, INpmPluginData, IPlugin } from "@documentalist/client";
+import { Compiler, File, NpmPackageInfo, NpmPluginData, Plugin } from "@documentalist/client";
 import { spawnSync } from "child_process";
 
-export interface INpmPluginOptions {
+export interface NpmPluginOptions {
     /** Whether to exclude packages marked `private`. */
     excludePrivate?: boolean;
 
@@ -30,10 +30,10 @@ export interface INpmPluginOptions {
  * package. It uses `npm info` to look up data about published packages, and
  * falls back to `package.json` info if the package is private or unpublished.
  */
-export class NpmPlugin implements IPlugin<INpmPluginData> {
-    public constructor(private options: INpmPluginOptions = {}) {}
+export class NpmPlugin implements Plugin<NpmPluginData> {
+    public constructor(private options: NpmPluginOptions = {}) {}
 
-    public compile(packageJsons: IFile[], dm: ICompiler): INpmPluginData {
+    public compile(packageJsons: File[], dm: Compiler): NpmPluginData {
         const info = packageJsons.map((pkg) => this.parseNpmInfo(pkg, dm));
         const { excludeNames, excludePrivate } = this.options;
         const npm = arrayToObject(
@@ -43,7 +43,7 @@ export class NpmPlugin implements IPlugin<INpmPluginData> {
         return { npm };
     }
 
-    private parseNpmInfo = (packageJson: IFile, dm: ICompiler): INpmPackage => {
+    private parseNpmInfo = (packageJson: File, dm: Compiler): NpmPackageInfo => {
         const sourcePath = dm.relativePath(packageJson.path);
         const json = JSON.parse(packageJson.read());
         const data = this.getNpmInfo(json.name);

--- a/packages/compiler/src/plugins/typescript/index.ts
+++ b/packages/compiler/src/plugins/typescript/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export { ITypescriptPluginData } from "@documentalist/client";
+export { TypescriptPluginData } from "@documentalist/client";
 export { TypescriptPlugin } from "./typescriptPlugin";

--- a/packages/compiler/src/plugins/typescript/typescriptPlugin.ts
+++ b/packages/compiler/src/plugins/typescript/typescriptPlugin.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Compiler, File, Plugin, TypescriptPluginData, TsDocEntry } from "@documentalist/client";
+import type { Compiler, File, Plugin, TsDocEntry, TypescriptPluginData } from "@documentalist/client";
 import { readFileSync } from "fs";
 import { dirname } from "path";
 import { tsconfigResolverSync } from "tsconfig-resolver";

--- a/packages/compiler/src/plugins/typescript/typescriptPlugin.ts
+++ b/packages/compiler/src/plugins/typescript/typescriptPlugin.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ICompiler, IFile, IPlugin, ITypescriptPluginData, TypescriptDocEntry } from "@documentalist/client";
+import type { Compiler, File, Plugin, TypescriptPluginData, TsDocEntry } from "@documentalist/client";
 import { readFileSync } from "fs";
 import { dirname } from "path";
 import { tsconfigResolverSync } from "tsconfig-resolver";
@@ -22,7 +22,7 @@ import { Application, LogLevel, TSConfigReader, TypeDocOptions, TypeDocReader } 
 import * as ts from "typescript";
 import { Visitor } from "./visitor";
 
-export interface ITypescriptPluginOptions {
+export interface TypescriptPluginOptions {
     /**
      * List of entry point modules.
      * @default ["src/index.ts"]
@@ -88,7 +88,7 @@ export interface ITypescriptPluginOptions {
     verbose?: boolean;
 }
 
-export class TypescriptPlugin implements IPlugin<ITypescriptPluginData> {
+export class TypescriptPlugin implements Plugin<TypescriptPluginData> {
     private typedocOptions: Partial<TypeDocOptions>;
 
     /*
@@ -100,7 +100,7 @@ export class TypescriptPlugin implements IPlugin<ITypescriptPluginData> {
     private tsPrograms: Map<string, ts.Program> = new Map();
     private typedocApps: Map<string, Application> = new Map();
 
-    public constructor(private options: ITypescriptPluginOptions = {}) {
+    public constructor(private options: TypescriptPluginOptions = {}) {
         const {
             entryPoints = ["src/index.ts"],
             includeDeclarations = false,
@@ -141,7 +141,7 @@ export class TypescriptPlugin implements IPlugin<ITypescriptPluginData> {
         return app;
     }
 
-    public async compile(files: IFile[], compiler: ICompiler): Promise<ITypescriptPluginData> {
+    public async compile(files: File[], compiler: Compiler): Promise<TypescriptPluginData> {
         // List of existing projects which contain some of the files to compile
         const existingProjectsToCompile: string[] = [];
 
@@ -172,7 +172,7 @@ export class TypescriptPlugin implements IPlugin<ITypescriptPluginData> {
             }
         }
 
-        const output: Record<string, TypescriptDocEntry> = {};
+        const output: Record<string, TsDocEntry> = {};
 
         for (const projectPath of existingProjectsToCompile) {
             const app = this.typedocApps.get(projectPath);
@@ -197,7 +197,7 @@ export class TypescriptPlugin implements IPlugin<ITypescriptPluginData> {
         return { typescript: output };
     }
 
-    private async getDocumentationOutput(compiler: ICompiler, app: Application) {
+    private async getDocumentationOutput(compiler: Compiler, app: Application) {
         const visitor = new Visitor(compiler, this.options);
         const project = await app.convert();
         if (project === undefined) {
@@ -211,7 +211,7 @@ export class TypescriptPlugin implements IPlugin<ITypescriptPluginData> {
         return compiler.objectify(visitor.visitProject(project), (i) => i.name);
     }
 
-    private resolveClosestTsconfig(file: IFile) {
+    private resolveClosestTsconfig(file: File) {
         const { path, reason } = tsconfigResolverSync({ cwd: dirname(file.path) });
 
         switch (reason) {

--- a/packages/compiler/src/plugins/typescript/visitor.ts
+++ b/packages/compiler/src/plugins/typescript/visitor.ts
@@ -15,20 +15,20 @@
  */
 
 import {
-    ICompiler,
-    ITsAccessor,
-    ITsClass,
-    ITsConstructor,
-    ITsDocBase,
-    ITsEnum,
-    ITsEnumMember,
-    ITsFlags,
-    ITsInterface,
-    ITsMethod,
-    ITsParameter,
-    ITsProperty,
-    ITsSignature,
-    ITsTypeAlias,
+    Compiler,
+    TsAccessor,
+    TsClass,
+    TsConstructor,
+    TsDocBase,
+    TsEnum,
+    TsEnumMember,
+    TsFlags,
+    TsInterface,
+    TsMethod,
+    TsParameter,
+    TsProperty,
+    TsSignature,
+    TsTypeAlias,
     Kind,
 } from "@documentalist/client";
 import { relative } from "path";
@@ -41,11 +41,11 @@ import {
     ReflectionKind,
     SignatureReflection,
 } from "typedoc";
-import { ITypescriptPluginOptions } from "./typescriptPlugin";
+import { TypescriptPluginOptions } from "./typescriptPlugin";
 import { resolveSignature, resolveTypeString } from "./typestring";
 
 export class Visitor {
-    public constructor(private compiler: ICompiler, private options: ITypescriptPluginOptions) {}
+    public constructor(private compiler: Compiler, private options: TypescriptPluginOptions) {}
 
     public visitProject(project: ProjectReflection) {
         const { excludePaths = [] } = this.options;
@@ -55,7 +55,7 @@ export class Visitor {
             ...this.visitChildren(project.getReflectionsByKind(ReflectionKind.Enum), this.visitEnum),
             ...this.visitChildren(project.getReflectionsByKind(ReflectionKind.Function), this.visitMethod),
             ...this.visitChildren(project.getReflectionsByKind(ReflectionKind.Interface), this.visitInterface),
-            ...this.visitChildren<ITsTypeAlias>(project.getReflectionsByKind(ReflectionKind.TypeAlias), (def) => ({
+            ...this.visitChildren<TsTypeAlias>(project.getReflectionsByKind(ReflectionKind.TypeAlias), (def) => ({
                 ...this.makeDocEntry(def, Kind.TypeAlias),
                 type: resolveTypeString(def.type),
             })),
@@ -65,7 +65,7 @@ export class Visitor {
         );
     }
 
-    private makeDocEntry<K extends Kind>(ref: Reflection, kind: K): ITsDocBase<K> {
+    private makeDocEntry<K extends Kind>(ref: Reflection, kind: K): TsDocBase<K> {
         let comment = ref.comment;
 
         if (comment === undefined && ref.isDeclaration()) {
@@ -90,7 +90,7 @@ export class Visitor {
         };
     }
 
-    private visitClass = (def: DeclarationReflection): ITsClass => ({
+    private visitClass = (def: DeclarationReflection): TsClass => ({
         ...this.visitInterface(def),
         accessors: this.visitChildren(def.getChildrenByKind(ReflectionKind.Accessor), this.visitAccessor),
         constructorType: this.visitChildren(
@@ -100,11 +100,11 @@ export class Visitor {
         kind: Kind.Class,
     });
 
-    private visitInterface = (def: DeclarationReflection): ITsInterface => ({
+    private visitInterface = (def: DeclarationReflection): TsInterface => ({
         ...this.makeDocEntry(def, Kind.Interface),
         extends: def.extendedTypes?.map(resolveTypeString),
         implements: def.implementedTypes?.map(resolveTypeString),
-        indexSignature: def.indexSignature && this.visitSignature(def.indexSignature),
+        indexSignature: def.indexSignature && this.visTsignature(def.indexSignature),
         methods: this.visitChildren(def.getChildrenByKind(ReflectionKind.Method), this.visitMethod, sortStaticFirst),
         properties: this.visitChildren(
             def.getChildrenByKind(ReflectionKind.Property),
@@ -113,33 +113,33 @@ export class Visitor {
         ),
     });
 
-    private visitConstructor = (def: DeclarationReflection): ITsConstructor => ({
+    private visitConstructor = (def: DeclarationReflection): TsConstructor => ({
         ...this.visitMethod(def),
         kind: Kind.Constructor,
     });
 
-    private visitEnum = (def: DeclarationReflection): ITsEnum => ({
+    private visitEnum = (def: DeclarationReflection): TsEnum => ({
         ...this.makeDocEntry(def, Kind.Enum),
-        members: this.visitChildren<ITsEnumMember>(def.getChildrenByKind(ReflectionKind.EnumMember), (m) => ({
+        members: this.visitChildren<TsEnumMember>(def.getChildrenByKind(ReflectionKind.EnumMember), (m) => ({
             ...this.makeDocEntry(m, Kind.EnumMember),
             defaultValue: getDefaultValue(m),
         })),
     });
 
-    private visitProperty = (def: DeclarationReflection): ITsProperty => ({
+    private visitProperty = (def: DeclarationReflection): TsProperty => ({
         ...this.makeDocEntry(def, Kind.Property),
         defaultValue: getDefaultValue(def),
         inheritedFrom: def.inheritedFrom && resolveTypeString(def.inheritedFrom),
         type: resolveTypeString(def.type),
     });
 
-    private visitMethod = (def: DeclarationReflection): ITsMethod => ({
+    private visitMethod = (def: DeclarationReflection): TsMethod => ({
         ...this.makeDocEntry(def, Kind.Method),
         inheritedFrom: def.inheritedFrom && resolveTypeString(def.inheritedFrom),
-        signatures: def.signatures !== undefined ? def.signatures.map((sig) => this.visitSignature(sig)) : [],
+        signatures: def.signatures !== undefined ? def.signatures.map((sig) => this.visTsignature(sig)) : [],
     });
 
-    private visitSignature = (sig: SignatureReflection): ITsSignature => ({
+    private visTsignature = (sig: SignatureReflection): TsSignature => ({
         ...this.makeDocEntry(sig, Kind.Signature),
         flags: undefined,
         parameters: (sig.parameters || []).map((param) => this.visitParameter(param)),
@@ -147,14 +147,14 @@ export class Visitor {
         type: resolveSignature(sig),
     });
 
-    private visitParameter = (param: ParameterReflection): ITsParameter => ({
+    private visitParameter = (param: ParameterReflection): TsParameter => ({
         ...this.makeDocEntry(param, Kind.Parameter),
         defaultValue: getDefaultValue(param),
         sourceUrl: undefined,
         type: resolveTypeString(param.type),
     });
 
-    private visitAccessor = (param: DeclarationReflection): ITsAccessor => {
+    private visitAccessor = (param: DeclarationReflection): TsAccessor => {
         let type: string;
         let getDocumentation;
         let setDocumentation;
@@ -182,8 +182,8 @@ export class Visitor {
         };
     };
 
-    /** Visits each child that passes the filter condition (based on options). */
-    private visitChildren<T extends ITsDocBase>(
+    /** VisTs each child that passes the filter condition (based on options). */
+    private visitChildren<T extends TsDocBase>(
         children: Reflection[],
         visitor: (def: DeclarationReflection) => T,
         comparator?: (a: T, b: T) => number,
@@ -196,7 +196,7 @@ export class Visitor {
     }
 
     /**
-     * Converts a typedoc comment object to a rendered `IBlock`.
+     * Converts a typedoc comment object to a rendered `Block`.
      */
     private renderComment(comment: Comment | undefined) {
         if (comment === undefined) {
@@ -255,7 +255,7 @@ function getSourceUrl(reflection: Reflection): string | undefined {
     return undefined;
 }
 
-function getFlags(ref: Reflection): ITsFlags | undefined {
+function getFlags(ref: Reflection): TsFlags | undefined {
     if (ref === undefined || ref.flags === undefined) {
         return undefined;
     }
@@ -285,7 +285,7 @@ function isNotExcluded(patterns: Array<string | RegExp>, value?: string) {
 }
 
 /** Sorts static members (`flags.isStatic`) before non-static members. */
-function sortStaticFirst<T extends ITsDocBase>({ flags: aFlags = {} }: T, { flags: bFlags = {} }: T) {
+function sortStaticFirst<T extends TsDocBase>({ flags: aFlags = {} }: T, { flags: bFlags = {} }: T) {
     if (aFlags.isStatic && bFlags.isStatic) {
         return 0;
     } else if (aFlags.isStatic) {

--- a/packages/compiler/src/plugins/typescript/visitor.ts
+++ b/packages/compiler/src/plugins/typescript/visitor.ts
@@ -16,6 +16,7 @@
 
 import {
     Compiler,
+    Kind,
     TsAccessor,
     TsClass,
     TsConstructor,
@@ -29,7 +30,6 @@ import {
     TsProperty,
     TsSignature,
     TsTypeAlias,
-    Kind,
 } from "@documentalist/client";
 import { relative } from "path";
 import {

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -17,14 +17,14 @@
 /**
  * Route
  */
-interface IRoute {
-    route: string;
+interface Route {
+    path: string;
     render: () => string;
 }
 
 class Router {
-    private routes: Record<string, IRoute> = {};
-    private currentRoute: IRoute | null = null;
+    private routes: Record<string, Route> = {};
+    private currentRoute: Route | null = null;
 
     constructor(public el: HTMLElement, private defaultRoute = "") {}
 
@@ -35,8 +35,8 @@ class Router {
         this.route();
     }
 
-    public register(route: IRoute) {
-        this.routes[route.route] = route;
+    public register(route: Route) {
+        this.routes[route.path] = route;
     }
 
     public route() {
@@ -46,7 +46,7 @@ class Router {
         if (this.el && route && route !== this.currentRoute) {
             this.currentRoute = route;
             this.el.innerHTML = route.render();
-            selectCurrent(route.route);
+            selectCurrent(route.path);
         } else {
             this.currentRoute = null;
         }
@@ -70,10 +70,9 @@ function selectCurrent(route: string) {
 const router = new Router(document.querySelector<HTMLElement>("#content")!, "overview");
 const routables = queryAll(document.body, "[data-route]");
 routables.forEach((routable) => {
-    const route = routable.getAttribute("data-route")!;
     router.register({
         render: () => routable.innerHTML,
-        route,
+        path: routable.getAttribute("data-route")!,
     });
 });
 router.start();

--- a/packages/docs/src/index.ts
+++ b/packages/docs/src/index.ts
@@ -71,8 +71,8 @@ const router = new Router(document.querySelector<HTMLElement>("#content")!, "ove
 const routables = queryAll(document.body, "[data-route]");
 routables.forEach((routable) => {
     router.register({
-        render: () => routable.innerHTML,
         path: routable.getAttribute("data-route")!,
+        render: () => routable.innerHTML,
     });
 });
 router.start();


### PR DESCRIPTION
Similar to what we did in Blueprint v5.0 here: https://github.com/palantir/blueprint/pull/4580

This is a good time to make this break alongside the other TypeScript-related breaking changes currently on develop.