### PR TITLE
[compiler] feat: upgrade to Marked v9.0

### DIFF
--- a/packages/compiler/changelog/@unreleased/pr-247.v2.yml
+++ b/packages/compiler/changelog/@unreleased/pr-247.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Upgrade to Marked v9.0
+  links:
+    - https://github.com/palantir/documentalist/pull/247

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -23,7 +23,7 @@
     "glob": "^10.3.10",
     "js-yaml": "^4.1.0",
     "kss": "^3.0.1",
-    "marked": "^4.0.12",
+    "marked": "^9.1.2",
     "tsconfig-resolver": "^3.0.1",
     "typedoc": "~0.25.2",
     "yargs": "^17.4.0"
@@ -32,7 +32,6 @@
     "@types/glob": "^8.1.0",
     "@types/jest": "^27.4.1",
     "@types/js-yaml": "^4.0.5",
-    "@types/marked": "^4.0.8",
     "@types/node": "^18.18.6",
     "@types/yargs": "^17.0.24",
     "jest": "^29.1.2",

--- a/packages/compiler/src/__tests__/__snapshots__/markdown.test.ts.snap
+++ b/packages/compiler/src/__tests__/__snapshots__/markdown.test.ts.snap
@@ -24,7 +24,7 @@ exports[`MarkdownPlugin snapshot 1`] = `
         "tag": "heading",
         "value": "I'm special",
       },
-      "<h2 id="im-regular">I&#39;m regular</h2>
+      "<h2>I&#39;m regular</h2>
 ",
       {
         "tag": "othertag",

--- a/packages/compiler/src/compilerImpl.ts
+++ b/packages/compiler/src/compilerImpl.ts
@@ -16,7 +16,7 @@
 
 import { Block, Compiler, HeadingTag, StringOrTag } from "@documentalist/client";
 import * as yaml from "js-yaml";
-import { marked } from "marked";
+import { marked, MarkedOptions } from "marked";
 import { relative } from "path";
 
 /**
@@ -33,7 +33,7 @@ const TAG_SPLIT_REGEX = /^(@\S+(?:\s+[^\n]+)?)$/gm;
 
 export interface CompilerOptions {
     /** Options for markdown rendering. See https://github.com/chjj/marked#options-1. */
-    markdown?: marked.MarkedOptions;
+    markdown?: MarkedOptions;
 
     /**
      * Reserved @tags that should be preserved in the contents string.
@@ -73,11 +73,7 @@ export class CompilerImpl implements Compiler {
         return { contents, contentsRaw, metadata };
     };
 
-    public renderMarkdown = (markdown: string) =>
-        marked(markdown, {
-            highlight: null as any,
-            ...this.options.markdown,
-        });
+    public renderMarkdown = (markdown: string) => marked(markdown, this.options.markdown);
 
     /**
      * Converts the content string into an array of `ContentNode`s. If the

--- a/yarn.lock
+++ b/yarn.lock
@@ -1418,11 +1418,6 @@
   resolved "https://registry.yarnpkg.com/@types/kss/-/kss-3.0.2.tgz#c9f2ff66e02ab1e0451d1f66c29744387c04d550"
   integrity sha512-krLl5EHn/Ku9zicmnC1Znume9M61Neryybvtq4JTunk7/tW0MmhakfFTVQCR3iLpz2ktnaT8+JErHZqnsF6CoA==
 
-"@types/marked@^4.0.8":
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.8.tgz#b316887ab3499d0a8f4c70b7bd8508f92d477955"
-  integrity sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw==
-
 "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -4530,10 +4525,15 @@ markdown-it@^12.0.2:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-marked@^4.0.12, marked@^4.3.0:
+marked@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
+
+marked@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-9.1.2.tgz#a54ca772d2b5a43de7d8ed40111354b4b7985527"
+  integrity sha512-qoKMJqK0w6vkLk8+KnKZAH6neUZSNaQqVZ/h2yZ9S7CbLuFHyS2viB0jnqcWF9UKjwsAbMrQtnQhdmdvOVOw9w==
 
 mdurl@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
`MarkedOptions` should be mostly backwards compatible.

`@types/marked` is no longer required now that the types are shipped with the package.

~This upgrade is intended to fix some rendering issues found here: https://github.com/palantir/blueprint/pull/6476#pullrequestreview-1695653203~ looks like it works fine without the upgrade. I tried this upgrade by using `yarn link` in the Blueprint repo, which means that the type breaks caused by the major bump should be minimal / negligible (I didn't have to fix any types).